### PR TITLE
refactor: remove plugin.meta and messageLintRule.meta nesting

### DIFF
--- a/.changeset/nasty-gorillas-collect.md
+++ b/.changeset/nasty-gorillas-collect.md
@@ -1,0 +1,17 @@
+---
+"@inlang/message-lint-rule-without-source": minor
+"@inlang/message-lint-rule": minor
+"@inlang/message-lint-rule-missing-translation": minor
+"@inlang/project-settings": minor
+"@inlang/message-lint-rule-identical-pattern": minor
+"@inlang/message-lint-rule-empty-pattern": minor
+"@inlang/plugin": minor
+"@inlang/plugin-paraglide": minor
+"@inlang/plugin-i18next": minor
+"@inlang/create-project": minor
+"@inlang/plugin-json": minor
+"@inlang/cli": minor
+"@inlang/sdk": minor
+---
+
+refactor: remove plugin.meta and messageLintRule.meta nesting

--- a/inlang/documentation/guide/develop-lint-rule.md
+++ b/inlang/documentation/guide/develop-lint-rule.md
@@ -36,7 +36,7 @@ import { id, displayName, description } from "../marketplace-manifest.json";
 
 export const yourLintRule: MessageLintRule = {
   meta: {
-    id: id as MessageLintRule["meta"]["id"],
+    id: id as MessageLintRule["id"],
     displayName,
     description,
   },

--- a/inlang/documentation/guide/develop-plugin.md
+++ b/inlang/documentation/guide/develop-plugin.md
@@ -36,7 +36,7 @@ import { id, displayName, description } from "../marketplace-manifest.json"
 
 export const plugin: Plugin<PluginSettings> = {
 	meta: {
-		id: id as Plugin["meta"]["id"],
+		id: id as Plugin["id"],
 		displayName,
 		description,
 	},

--- a/inlang/source-code/cli/src/commands/lint/lint.test.ts
+++ b/inlang/source-code/cli/src/commands/lint/lint.test.ts
@@ -69,11 +69,9 @@ async function setupProject(enabledLintRule?: MessageLintRule) {
 	)
 
 	const _mockPlugin: Plugin = {
-		meta: {
-			id: "plugin.inlang.json",
-			description: { en: "Mock plugin description" },
-			displayName: { en: "Mock Plugin" },
-		},
+		id: "plugin.inlang.json",
+		description: { en: "Mock plugin description" },
+		displayName: { en: "Mock Plugin" },
 		loadMessages: () => exampleMessages,
 		saveMessages: () => undefined as any,
 	}
@@ -97,12 +95,10 @@ async function setupProject(enabledLintRule?: MessageLintRule) {
 describe("lint command", () => {
 	it("succeed on lint success", async () => {
 		const enabledLintRule: MessageLintRule = {
-			meta: {
-				id: "messageLintRule.namespace.enabled",
-				description: { en: "Mock lint rule description" },
-				displayName: { en: "Mock Lint Rule" },
-			},
-			message: () => {
+			id: "messageLintRule.namespace.enabled",
+			description: { en: "Mock lint rule description" },
+			displayName: { en: "Mock Lint Rule" },
+			run: () => {
 				;/ * no lint reports for this test case * /
 			},
 		}
@@ -134,12 +130,10 @@ describe("lint command", () => {
 
 	it("show lint reports", async () => {
 		const enabledLintRule: MessageLintRule = {
-			meta: {
-				id: "messageLintRule.namespace.enabled",
-				description: { en: "Mock lint rule description" },
-				displayName: { en: "Mock Lint Rule" },
-			},
-			message: ({ report }) => {
+			id: "messageLintRule.namespace.enabled",
+			description: { en: "Mock lint rule description" },
+			displayName: { en: "Mock Lint Rule" },
+			run: ({ report }) => {
 				report({
 					messageId: "some-message-1",
 					languageTag: "en",

--- a/inlang/source-code/cli/src/commands/machine/translate.test.ts
+++ b/inlang/source-code/cli/src/commands/machine/translate.test.ts
@@ -65,11 +65,9 @@ describe("translate command", () => {
 			)
 
 			const _mockPlugin: Plugin = {
-				meta: {
-					id: "plugin.inlang.json",
-					description: { en: "Mock plugin description" },
-					displayName: { en: "Mock Plugin" },
-				},
+				id: "plugin.inlang.json",
+				description: { en: "Mock plugin description" },
+				displayName: { en: "Mock Plugin" },
 				loadMessages: () => exampleMessages,
 				saveMessages: () => undefined as any,
 			}

--- a/inlang/source-code/create-project/src/migrate.ts
+++ b/inlang/source-code/create-project/src/migrate.ts
@@ -116,8 +116,8 @@ export async function migrateProjectSettings(args: {
 
 				const pluginName =
 					moduleDetections.values().next().value || lintRuleDetections.values().next().value
-				const pluginId: Plugin["meta"]["id"] = ("plugin.inlang." +
-					(pluginName || `<please add your plugin id for ${url} here>`)) as Plugin["meta"]["id"]
+				const pluginId: Plugin["id"] = ("plugin.inlang." +
+					(pluginName || `<please add your plugin id for ${url} here>`)) as Plugin["id"]
 
 				return {
 					default: (pluginArg: any) => {
@@ -202,7 +202,7 @@ function lineParsing(
 	}
 
 	const pluginName: string = moduleDetections.values().next().value
-	const pluginId: Plugin["meta"]["id"] = `plugin.inlang.${pluginName}`
+	const pluginId: Plugin["id"] = `plugin.inlang.${pluginName}`
 
 	config.modules = [
 		pluginUrls[pluginName] || `<please add your missing plugin url here>`,

--- a/inlang/source-code/create-project/src/tryAutoGenProjectSettings.ts
+++ b/inlang/source-code/create-project/src/tryAutoGenProjectSettings.ts
@@ -82,7 +82,7 @@ export async function tryAutoGenProjectSettings(args: {
 export async function autoGenProject(args: {
 	nodeishFs: NodeishFilesystem
 	pathJoin: (...args: string[]) => string
-}): Promise<{ settings?: ProjectSettings; warnings: string[]; pluginId?: Plugin["meta"]["id"] }> {
+}): Promise<{ settings?: ProjectSettings; warnings: string[]; pluginId?: Plugin["id"] }> {
 	const rootDir = "./"
 	const warnings: string[] = []
 
@@ -136,7 +136,7 @@ export async function autoGenProject(args: {
 		)
 	}
 
-	const pluginId: Plugin["meta"]["id"] = `plugin.inlang.${pluginName}`
+	const pluginId: Plugin["id"] = `plugin.inlang.${pluginName}`
 
 	const settings: ProjectSettings = {
 		$schema: "https://inlang.com/schema/project-settings",

--- a/inlang/source-code/message-lint-rules/emptyPattern/src/emptyPattern.test.ts
+++ b/inlang/source-code/message-lint-rules/emptyPattern/src/emptyPattern.test.ts
@@ -19,12 +19,14 @@ const messages = [message1]
 
 test("should not report if all messages are present", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en", "de"],
-		ruleLevels: {
-			[emptyPatternRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "de"],
+			modules: [],
+			messageLintRuleLevels: {
+				[emptyPatternRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [emptyPatternRule],
@@ -36,12 +38,14 @@ test("should not report if all messages are present", async () => {
 
 test("should report if no patterns are defined", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en", "es"],
-		ruleLevels: {
-			[emptyPatternRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "es"],
+			modules: [],
+			messageLintRuleLevels: {
+				[emptyPatternRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [emptyPatternRule],
@@ -54,12 +58,14 @@ test("should report if no patterns are defined", async () => {
 
 test("should report if a message has a pattern with only one text element that is an empty string", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en", "cn"],
-		ruleLevels: {
-			[emptyPatternRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "cn"],
+			modules: [],
+			messageLintRuleLevels: {
+				[emptyPatternRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [emptyPatternRule],
@@ -73,12 +79,14 @@ test("should report if a message has a pattern with only one text element that i
 describe("reported by missingTranslationRule", () => {
 	test("should not report if a languageTag is not present", async () => {
 		const result = await lintSingleMessage({
-			sourceLanguageTag: "en",
-			languageTags: ["en", "it"],
-			ruleLevels: {
-				[emptyPatternRule.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: ["en", "it"],
+				modules: [],
+				messageLintRuleLevels: {
+					[emptyPatternRule.id]: "warning",
+				},
 			},
-			ruleSettings: {},
 			messages,
 			message: message1,
 			rules: [emptyPatternRule],
@@ -90,12 +98,14 @@ describe("reported by missingTranslationRule", () => {
 
 	test("should not report if no variants are defined", async () => {
 		const result = await lintSingleMessage({
-			sourceLanguageTag: "en",
-			languageTags: ["en", "fr"],
-			ruleLevels: {
-				[emptyPatternRule.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: ["en", "fr"],
+				modules: [],
+				messageLintRuleLevels: {
+					[emptyPatternRule.id]: "warning",
+				},
 			},
-			ruleSettings: {},
 			messages,
 			message: message1,
 			rules: [emptyPatternRule],

--- a/inlang/source-code/message-lint-rules/emptyPattern/src/emptyPattern.ts
+++ b/inlang/source-code/message-lint-rules/emptyPattern/src/emptyPattern.ts
@@ -2,18 +2,16 @@ import type { MessageLintRule } from "@inlang/message-lint-rule"
 import { id, displayName, description } from "../marketplace-manifest.json"
 
 export const emptyPatternRule: MessageLintRule = {
-	meta: {
-		id: id as MessageLintRule["meta"]["id"],
-		displayName,
-		description,
-	},
-	message: ({ message: { id, variants }, languageTags, sourceLanguageTag, report }) => {
-		const translatedLanguageTags = languageTags.filter(
-			(languageTag) => languageTag !== sourceLanguageTag,
+	id: id as MessageLintRule["id"],
+	displayName,
+	description,
+	run: ({ message, settings, report }) => {
+		const translatedLanguageTags = settings.languageTags.filter(
+			(languageTag) => languageTag !== settings.sourceLanguageTag,
 		)
 		for (const translatedLanguageTag of translatedLanguageTags) {
 			const filteredVariants =
-				variants.filter((variant) => variant.languageTag === translatedLanguageTag) ?? []
+				message.variants.filter((variant) => variant.languageTag === translatedLanguageTag) ?? []
 			if (filteredVariants.length === 0) return
 			const patterns = filteredVariants.flatMap(({ pattern }) => pattern)
 			if (!patterns.length) {

--- a/inlang/source-code/message-lint-rules/identicalPattern/src/identicalPattern.test.ts
+++ b/inlang/source-code/message-lint-rules/identicalPattern/src/identicalPattern.test.ts
@@ -18,12 +18,14 @@ const messages = [message1]
 
 test("should report if identical message found in another language", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en"],
-		ruleLevels: {
-			[identicalPatternRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en"],
+			modules: [],
+			messageLintRuleLevels: {
+				[identicalPatternRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [identicalPatternRule],
@@ -36,13 +38,14 @@ test("should report if identical message found in another language", async () =>
 
 test("should not report if pattern is present in 'ignore'", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en"],
-		ruleLevels: {
-			[identicalPatternRule.meta.id]: "warning",
-		},
-		ruleSettings: {
-			[identicalPatternRule.meta.id]: {
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en"],
+			modules: [],
+			messageLintRuleLevels: {
+				[identicalPatternRule.id]: "warning",
+			},
+			[identicalPatternRule.id as any]: {
 				ignore: ["This is Inlang"],
 			},
 		},

--- a/inlang/source-code/message-lint-rules/messageWithoutSource/src/messageWithoutSource.test.ts
+++ b/inlang/source-code/message-lint-rules/messageWithoutSource/src/messageWithoutSource.test.ts
@@ -17,12 +17,14 @@ const messages = [message1]
 
 test("should not report if source message present", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en"],
-		ruleLevels: {
-			[messageWithoutSourceRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en"],
+			modules: [],
+			messageLintRuleLevels: {
+				[messageWithoutSourceRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [messageWithoutSourceRule],
@@ -34,12 +36,14 @@ test("should not report if source message present", async () => {
 
 test("should report if source message is missing", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "it",
-		languageTags: ["it"],
-		ruleLevels: {
-			[messageWithoutSourceRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "it",
+			languageTags: ["it"],
+			modules: [],
+			messageLintRuleLevels: {
+				[messageWithoutSourceRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [messageWithoutSourceRule],

--- a/inlang/source-code/message-lint-rules/messageWithoutSource/src/messageWithoutSource.ts
+++ b/inlang/source-code/message-lint-rules/messageWithoutSource/src/messageWithoutSource.ts
@@ -2,16 +2,14 @@ import type { MessageLintRule } from "@inlang/message-lint-rule"
 import { id, displayName, description } from "../marketplace-manifest.json"
 
 export const messageWithoutSourceRule: MessageLintRule = {
-	meta: {
-		id: id as MessageLintRule["meta"]["id"],
-		displayName,
-		description,
-	},
-	message: ({ message: { id, variants }, sourceLanguageTag, report }) => {
-		if (!variants.some((variant) => variant.languageTag === sourceLanguageTag)) {
+	id: id as MessageLintRule["id"],
+	displayName,
+	description,
+	run: ({ message, settings, report }) => {
+		if (!message.variants.some((variant) => variant.languageTag === settings.sourceLanguageTag)) {
 			report({
 				messageId: id,
-				languageTag: sourceLanguageTag,
+				languageTag: settings.sourceLanguageTag,
 				body: {
 					en: `Message with id '${id}' is specified, but missing in the source.`,
 				},

--- a/inlang/source-code/message-lint-rules/missingTranslation/src/missingTranslation.test.ts
+++ b/inlang/source-code/message-lint-rules/missingTranslation/src/missingTranslation.test.ts
@@ -19,12 +19,14 @@ const messages = [message1]
 
 test("should not report if all messages are present", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en", "de"],
-		ruleLevels: {
-			[missingTranslationRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "de"],
+			modules: [],
+			messageLintRuleLevels: {
+				[missingTranslationRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [missingTranslationRule],
@@ -36,12 +38,14 @@ test("should not report if all messages are present", async () => {
 
 test("should report if a languageTag is not present", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en", "it"],
-		ruleLevels: {
-			[missingTranslationRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "it"],
+			modules: [],
+			messageLintRuleLevels: {
+				[missingTranslationRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [missingTranslationRule],
@@ -54,12 +58,14 @@ test("should report if a languageTag is not present", async () => {
 
 test("should report if no variants are defined", async () => {
 	const result = await lintSingleMessage({
-		sourceLanguageTag: "en",
-		languageTags: ["en", "fr"],
-		ruleLevels: {
-			[missingTranslationRule.meta.id]: "warning",
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "fr"],
+			modules: [],
+			messageLintRuleLevels: {
+				[missingTranslationRule.id]: "warning",
+			},
 		},
-		ruleSettings: {},
 		messages,
 		message: message1,
 		rules: [missingTranslationRule],
@@ -73,12 +79,14 @@ test("should report if no variants are defined", async () => {
 describe("reported by emptyPattern lintRule", () => {
 	test("should not report if no patterns are defined", async () => {
 		const result = await lintSingleMessage({
-			sourceLanguageTag: "en",
-			languageTags: ["en", "es"],
-			ruleLevels: {
-				[missingTranslationRule.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: ["en", "es"],
+				modules: [],
+				messageLintRuleLevels: {
+					[missingTranslationRule.id]: "warning",
+				},
 			},
-			ruleSettings: {},
 			messages,
 			message: message1,
 			rules: [missingTranslationRule],
@@ -90,12 +98,14 @@ describe("reported by emptyPattern lintRule", () => {
 
 	test("should not report if a message has a pattern with only one text element that is an empty string", async () => {
 		const result = await lintSingleMessage({
-			sourceLanguageTag: "en",
-			languageTags: ["en", "cn"],
-			ruleLevels: {
-				[missingTranslationRule.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: ["en", "cn"],
+				modules: [],
+				messageLintRuleLevels: {
+					[missingTranslationRule.id]: "warning",
+				},
 			},
-			ruleSettings: {},
 			messages,
 			message: message1,
 			rules: [missingTranslationRule],

--- a/inlang/source-code/message-lint-rules/missingTranslation/src/missingTranslation.ts
+++ b/inlang/source-code/message-lint-rules/missingTranslation/src/missingTranslation.ts
@@ -2,19 +2,17 @@ import type { MessageLintRule } from "@inlang/message-lint-rule"
 import { id, displayName, description } from "../marketplace-manifest.json"
 
 export const missingTranslationRule: MessageLintRule = {
-	meta: {
-		id: id as MessageLintRule["meta"]["id"],
-		displayName,
-		description,
-	},
-	message: ({ message: { id, variants }, languageTags, sourceLanguageTag, report }) => {
-		const translatedLanguageTags = languageTags.filter(
-			(languageTag) => languageTag !== sourceLanguageTag,
+	id: id as MessageLintRule["id"],
+	displayName,
+	description,
+	run: ({ message, settings, report }) => {
+		const translatedLanguageTags = settings.languageTags.filter(
+			(languageTag) => languageTag !== settings.sourceLanguageTag,
 		)
 
 		for (const translatedLanguageTag of translatedLanguageTags) {
 			const filteredVariants =
-				variants.filter((variant) => variant.languageTag === translatedLanguageTag) ?? []
+				message.variants.filter((variant) => variant.languageTag === translatedLanguageTag) ?? []
 			if (!filteredVariants.length) {
 				report({
 					messageId: id,

--- a/inlang/source-code/plugins/i18next/src/plugin.ts
+++ b/inlang/source-code/plugins/i18next/src/plugin.ts
@@ -62,11 +62,9 @@ function defaultNesting() {
 }
 
 export const plugin: Plugin<PluginSettings> = {
-	meta: {
-		id: id as Plugin["meta"]["id"],
-		displayName,
-		description,
-	},
+	id: id as Plugin["id"],
+	displayName,
+	description,
 	loadMessages: async ({ languageTags, sourceLanguageTag, settings, nodeishFs }) => {
 		settings.variableReferencePattern = settings.variableReferencePattern || ["{{", "}}"]
 		throwIfInvalidSettings(settings)

--- a/inlang/source-code/plugins/json/src/plugin.ts
+++ b/inlang/source-code/plugins/json/src/plugin.ts
@@ -62,11 +62,9 @@ function defaultNesting() {
 }
 
 export const plugin: Plugin<PluginSettings> = {
-	meta: {
-		id: id as Plugin["meta"]["id"],
-		displayName,
-		description,
-	},
+	id: id as Plugin["id"],
+	displayName,
+	description,
 	loadMessages: async ({ languageTags, sourceLanguageTag, settings, nodeishFs }) => {
 		settings.variableReferencePattern = settings.variableReferencePattern || ["{", "}"]
 		throwIfInvalidSettings(settings)

--- a/inlang/source-code/plugins/paraglide/src/plugin.ts
+++ b/inlang/source-code/plugins/paraglide/src/plugin.ts
@@ -5,11 +5,9 @@ import { id, displayName, description } from "../marketplace-manifest.json"
 // ------------------------------------------------------------------------------------------------
 
 export const plugin: Plugin = {
-	meta: {
-		id: id,
-		displayName,
-		description,
-	},
+	id: id,
+	displayName,
+	description,
 	addCustomApi() {
 		return {
 			"app.inlang.ideExtension": ideExtensionConfig(),

--- a/inlang/source-code/sdk/src/adapter/solidAdapter.test.ts
+++ b/inlang/source-code/sdk/src/adapter/solidAdapter.test.ts
@@ -29,11 +29,9 @@ const config: ProjectSettings = {
 }
 
 const mockPlugin: Plugin = {
-	meta: {
-		id: "plugin.project.i18next",
-		description: { en: "Mock plugin description" },
-		displayName: { en: "Mock Plugin" },
-	},
+	id: "plugin.project.i18next",
+	description: { en: "Mock plugin description" },
+	displayName: { en: "Mock Plugin" },
 	loadMessages: () => exampleMessages,
 	saveMessages: () => undefined,
 }
@@ -75,12 +73,10 @@ const exampleMessages: Message[] = [
 ]
 
 const mockLintRule: MessageLintRule = {
-	meta: {
-		id: "messageLintRule.namespace.mock",
-		description: { en: "Mock lint rule description" },
-		displayName: { en: "Mock Lint Rule" },
-	},
-	message: () => undefined,
+	id: "messageLintRule.namespace.mock",
+	description: { en: "Mock lint rule description" },
+	displayName: { en: "Mock Lint Rule" },
+	run: () => undefined,
 }
 
 const $import: ImportFunction = async (name) => ({
@@ -172,14 +168,12 @@ describe("messages", () => {
 			},
 		}
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.mock.id",
-				displayName: {
-					en: "hello",
-				},
-				description: {
-					en: "wo",
-				},
+			id: "plugin.mock.id",
+			displayName: {
+				en: "hello",
+			},
+			description: {
+				en: "wo",
 			},
 			loadMessages: ({ languageTags }) => (languageTags.length ? exampleMessages : []),
 			saveMessages: () => undefined,

--- a/inlang/source-code/sdk/src/api.ts
+++ b/inlang/source-code/sdk/src/api.ts
@@ -12,7 +12,9 @@ import type {
 import type { ResolvedPluginApi } from "./resolve-modules/plugins/types.js"
 
 export type InstalledPlugin = {
-	meta: Plugin["meta"]
+	id: Plugin["id"]
+	displayName: Plugin["displayName"]
+	description: Plugin["description"]
 	/**
 	 * The module which the plugin is installed from.
 	 */
@@ -21,12 +23,14 @@ export type InstalledPlugin = {
 }
 
 export type InstalledMessageLintRule = {
-	meta: MessageLintRule["meta"]
+	id: MessageLintRule["id"]
+	displayName: MessageLintRule["displayName"]
+	description: MessageLintRule["description"]
 	/**
 	 * The module which the lint rule is installed from.
 	 */
 	module: string
-	lintLevel: MessageLintLevel
+	level: MessageLintLevel
 }
 
 export type InlangProject = {

--- a/inlang/source-code/sdk/src/createMessageLintReportsQuery.ts
+++ b/inlang/source-code/sdk/src/createMessageLintReportsQuery.ts
@@ -3,12 +3,7 @@ import { createSubscribable } from "./loadProject.js"
 import type { InlangProject, InstalledMessageLintRule, MessageLintReportsQueryApi } from "./api.js"
 import type { ProjectSettings } from "@inlang/project-settings"
 import type { resolveModules } from "./resolve-modules/index.js"
-import type {
-	JSONObject,
-	MessageLintReport,
-	MessageLintRule,
-	Message,
-} from "./versionedInterfaces.js"
+import type { MessageLintReport, Message } from "./versionedInterfaces.js"
 import { lintSingleMessage } from "./lint/index.js"
 import { ReactiveMap } from "./reactivity/map.js"
 
@@ -17,7 +12,7 @@ import { ReactiveMap } from "./reactivity/map.js"
  */
 export function createMessageLintReportsQuery(
 	messages: () => Array<Message> | undefined,
-	config: () => ProjectSettings | undefined,
+	settings: () => ProjectSettings,
 	installedMessageLintRules: () => Array<InstalledMessageLintRule>,
 	resolvedModules: () => Awaited<ReturnType<typeof resolveModules>> | undefined,
 ): InlangProject["query"]["messageLintReports"] {
@@ -25,25 +20,25 @@ export function createMessageLintReportsQuery(
 	const index = new ReactiveMap<MessageLintReport["messageId"], MessageLintReport[]>()
 
 	createEffect(() => {
-		const msgs = messages()
-		const conf = config()
 		const modules = resolvedModules()
+		const _messages = messages()
+		const _settings = settings()
 
-		if (msgs && conf && modules) {
+		if (_messages && _settings && modules) {
 			// console.log("new calculation")
 			// index.clear()
-			for (const message of msgs) {
+			for (const message of _messages) {
 				// TODO: only lint changed messages and update arrays selectively
 
 				lintSingleMessage({
 					rules: modules.messageLintRules,
-					ruleSettings: conf as Record<MessageLintRule["meta"]["id"], JSONObject>,
-					ruleLevels: Object.fromEntries(
-						installedMessageLintRules().map((rule) => [rule.meta.id, rule.lintLevel]),
-					),
-					sourceLanguageTag: conf.sourceLanguageTag,
-					languageTags: conf.languageTags,
-					messages: msgs,
+					settings: {
+						..._settings,
+						messageLintRuleLevels: Object.fromEntries(
+							installedMessageLintRules().map((rule) => [rule.id, rule.level]),
+						),
+					},
+					messages: _messages,
 					message: message,
 				}).then((report) => {
 					if (

--- a/inlang/source-code/sdk/src/lint/message/lintMessages.test.ts
+++ b/inlang/source-code/sdk/src/lint/message/lintMessages.test.ts
@@ -4,21 +4,17 @@ import type { MessageLintReport, MessageLintRule } from "@inlang/message-lint-ru
 import type { Message } from "@inlang/message"
 
 const lintRule1 = {
-	meta: {
-		id: "messageLintRule.x.1",
-		displayName: { en: "" },
-		description: { en: "" },
-	},
-	message: vi.fn(),
+	id: "messageLintRule.x.1",
+	displayName: { en: "" },
+	description: { en: "" },
+	run: vi.fn(),
 } satisfies MessageLintRule
 
 const lintRule2 = {
-	meta: {
-		id: "messageLintRule.x.2",
-		displayName: { en: "" },
-		description: { en: "" },
-	},
-	message: vi.fn(),
+	id: "messageLintRule.x.2",
+	displayName: { en: "" },
+	description: { en: "" },
+	run: vi.fn(),
 } satisfies MessageLintRule
 
 const message1 = { id: "m1" } as Message
@@ -34,50 +30,54 @@ describe("lintMessages", async () => {
 
 	test("it should await all messages", async () => {
 		let called = 0
-		lintRule2.message.mockImplementation(async () => {
+		lintRule2.run.mockImplementation(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			called++
 		})
 
 		await lintMessages({
-			ruleLevels: {
-				[lintRule1.meta.id]: "warning",
-				[lintRule2.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: [],
+				modules: [],
+				messageLintRuleLevels: {
+					[lintRule1.id]: "warning",
+					[lintRule2.id]: "warning",
+				},
 			},
-			ruleSettings: {},
-			sourceLanguageTag: "en",
-			languageTags: [],
 			messages,
 			rules: [lintRule1, lintRule2],
 		})
 
-		expect(lintRule1.message).toHaveBeenCalledTimes(3)
+		expect(lintRule1.run).toHaveBeenCalledTimes(3)
 		expect(called).toBe(3)
 	})
 
 	test("it should process all messages and rules in parallel", async () => {
 		const fn = vi.fn()
 
-		lintRule1.message.mockImplementation(async ({ message }) => {
+		lintRule1.run.mockImplementation(async ({ message }) => {
 			fn("r1", "before", message.id)
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			fn("r1", "after", message.id)
 		})
-		lintRule2.message.mockImplementation(async ({ message }) => {
+		lintRule2.run.mockImplementation(async ({ message }) => {
 			fn("r2", "before", message.id)
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			fn("r2", "after", message.id)
 		})
 
 		await lintMessages({
-			ruleLevels: {
-				[lintRule1.meta.id]: "warning",
-				[lintRule2.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: [],
+				modules: [],
+				messageLintRuleLevels: {
+					[lintRule1.id]: "warning",
+					[lintRule2.id]: "warning",
+				},
 			},
-			ruleSettings: {},
 			rules: [lintRule1, lintRule2],
-			sourceLanguageTag: "en",
-			languageTags: [],
 			messages,
 		})
 
@@ -97,21 +97,23 @@ describe("lintMessages", async () => {
 	})
 
 	test("it should not abort the linting process when errors occur", async () => {
-		lintRule1.message.mockImplementation(({ report }) => {
+		lintRule1.run.mockImplementation(({ report }) => {
 			report({} as MessageLintReport)
 		})
-		lintRule2.message.mockImplementation(() => {
+		lintRule2.run.mockImplementation(() => {
 			throw new Error("error")
 		})
 
 		const { data, errors } = await lintMessages({
-			ruleLevels: {
-				[lintRule1.meta.id]: "warning",
-				[lintRule2.meta.id]: "warning",
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: [],
+				modules: [],
+				messageLintRuleLevels: {
+					[lintRule1.id]: "warning",
+					[lintRule2.id]: "warning",
+				},
 			},
-			ruleSettings: {},
-			sourceLanguageTag: "en",
-			languageTags: [],
 			messages,
 			rules: [lintRule1, lintRule2],
 		})

--- a/inlang/source-code/sdk/src/lint/message/lintMessages.ts
+++ b/inlang/source-code/sdk/src/lint/message/lintMessages.ts
@@ -1,19 +1,11 @@
 import type { Message } from "@inlang/message"
 import { lintSingleMessage } from "./lintSingleMessage.js"
 import type { MessagedLintRuleThrowedError } from "./errors.js"
-import type { LanguageTag } from "@inlang/language-tag"
-import type { JSONObject } from "@inlang/json-types"
-import type {
-	MessageLintLevel,
-	MessageLintReport,
-	MessageLintRule,
-} from "@inlang/message-lint-rule"
+import type { MessageLintReport, MessageLintRule } from "@inlang/message-lint-rule"
+import type { ProjectSettings } from "@inlang/project-settings"
 
 export const lintMessages = async (args: {
-	sourceLanguageTag: LanguageTag
-	languageTags: LanguageTag[]
-	ruleSettings: Record<MessageLintRule["meta"]["id"], JSONObject>
-	ruleLevels: Record<MessageLintRule["meta"]["id"], MessageLintLevel>
+	settings: ProjectSettings & Required<Pick<ProjectSettings, "messageLintRuleLevels">>
 	rules: MessageLintRule[]
 	messages: Message[]
 }): Promise<{ data: MessageLintReport[]; errors: MessagedLintRuleThrowedError[] }> => {

--- a/inlang/source-code/sdk/src/loadProject.test.ts
+++ b/inlang/source-code/sdk/src/loadProject.test.ts
@@ -33,11 +33,9 @@ const settings: ProjectSettings = {
 }
 
 const mockPlugin: Plugin = {
-	meta: {
-		id: "plugin.project.i18next",
-		description: { en: "Mock plugin description" },
-		displayName: { en: "Mock Plugin" },
-	},
+	id: "plugin.project.i18next",
+	description: { en: "Mock plugin description" },
+	displayName: { en: "Mock Plugin" },
 	loadMessages: () => exampleMessages,
 	saveMessages: () => undefined as any,
 	addCustomApi: () => ({
@@ -84,12 +82,10 @@ const exampleMessages: Message[] = [
 ]
 
 const mockMessageLintRule: MessageLintRule = {
-	meta: {
-		id: "messageLintRule.project.mock",
-		description: { en: "Mock lint rule description" },
-		displayName: { en: "Mock Lint Rule" },
-	},
-	message: () => undefined,
+	id: "messageLintRule.project.mock",
+	description: { en: "Mock lint rule description" },
+	displayName: { en: "Mock Lint Rule" },
+	run: () => undefined,
 }
 
 const _import: ImportFunction = async (name) =>
@@ -304,14 +300,18 @@ describe("functionality", () => {
 			})
 
 			expect(project.installed.plugins()[0]).toStrictEqual({
-				meta: mockPlugin.meta,
+				id: mockPlugin.id,
+				description: mockPlugin.description,
+				displayName: mockPlugin.displayName,
 				module: settings.modules[0],
 			})
 
 			expect(project.installed.messageLintRules()[0]).toEqual({
-				meta: mockMessageLintRule.meta,
+				id: mockMessageLintRule.id,
+				description: mockMessageLintRule.description,
+				displayName: mockMessageLintRule.displayName,
 				module: settings.modules[1],
-				lintLevel: "warning",
+				level: "warning",
 			})
 		})
 
@@ -332,18 +332,16 @@ describe("functionality", () => {
 				_import,
 			})
 
-			expect(project.installed.messageLintRules()[0]?.lintLevel).toBe("warning")
+			expect(project.installed.messageLintRules()[0]?.level).toBe("warning")
 		})
 
 		// yep, this is a typical "hm, we have a bug here, let's write a test for it" test
 		it("should return lint reports if disabled is not set", async () => {
 			const _mockLintRule: MessageLintRule = {
-				meta: {
-					id: "messageLintRule.namespace.mock",
-					description: { en: "Mock lint rule description" },
-					displayName: { en: "Mock Lint Rule" },
-				},
-				message: ({ report }) => {
+				id: "messageLintRule.namespace.mock",
+				description: { en: "Mock lint rule description" },
+				displayName: { en: "Mock Lint Rule" },
+				run: ({ report }) => {
 					report({
 						messageId: "some-message-1",
 						languageTag: "en",
@@ -352,11 +350,9 @@ describe("functionality", () => {
 				},
 			}
 			const _mockPlugin: Plugin = {
-				meta: {
-					id: "plugin.project.i18next",
-					description: { en: "Mock plugin description" },
-					displayName: { en: "Mock Plugin" },
-				},
+				id: "plugin.project.i18next",
+				description: { en: "Mock plugin description" },
+				displayName: { en: "Mock Plugin" },
 				loadMessages: () => [{ id: "some-message", selectors: [], variants: [] }],
 				saveMessages: () => undefined,
 			}
@@ -384,18 +380,16 @@ describe("functionality", () => {
 			await new Promise((resolve) => setTimeout(resolve, 510))
 
 			expect(project.query.messageLintReports.getAll()).toHaveLength(1)
-			expect(project.query.messageLintReports.getAll()?.[0]?.ruleId).toBe(_mockLintRule.meta.id)
+			expect(project.query.messageLintReports.getAll()?.[0]?.ruleId).toBe(_mockLintRule.id)
 			expect(project.installed.messageLintRules()).toHaveLength(1)
 		})
 
 		it("should return lint reports for a single message", async () => {
 			const _mockLintRule: MessageLintRule = {
-				meta: {
-					id: "messageLintRule.namepsace.mock",
-					description: { en: "Mock lint rule description" },
-					displayName: { en: "Mock Lint Rule" },
-				},
-				message: ({ report }) => {
+				id: "messageLintRule.namepsace.mock",
+				description: { en: "Mock lint rule description" },
+				displayName: { en: "Mock Lint Rule" },
+				run: ({ report }) => {
 					report({
 						messageId: "some-message",
 						languageTag: "en",
@@ -404,11 +398,9 @@ describe("functionality", () => {
 				},
 			}
 			const _mockPlugin: Plugin = {
-				meta: {
-					id: "plugin.project.i18next",
-					description: { en: "Mock plugin description" },
-					displayName: { en: "Mock Plugin" },
-				},
+				id: "plugin.project.i18next",
+				description: { en: "Mock plugin description" },
+				displayName: { en: "Mock Plugin" },
 				loadMessages: () => [{ id: "some-message", selectors: [], variants: [] }],
 				saveMessages: () => undefined,
 			}
@@ -507,11 +499,9 @@ describe("functionality", () => {
 			const mockSaveFn = vi.fn()
 
 			const _mockPlugin: Plugin = {
-				meta: {
-					id: "plugin.project.json",
-					description: { en: "Mock plugin description" },
-					displayName: { en: "Mock Plugin" },
-				},
+				id: "plugin.project.json",
+				description: { en: "Mock plugin description" },
+				displayName: { en: "Mock Plugin" },
 				loadMessages: () => exampleMessages,
 				saveMessages: mockSaveFn,
 			}

--- a/inlang/source-code/sdk/src/loadProject.ts
+++ b/inlang/source-code/sdk/src/loadProject.ts
@@ -133,13 +133,14 @@ export const loadProject = async (args: {
 			return resolvedModules()!.messageLintRules.map(
 				(rule) =>
 					({
-						meta: rule.meta,
+						id: rule.id,
+						displayName: rule.displayName,
+						description: rule.description,
 						module:
-							resolvedModules()?.meta.find((m) => m.id.includes(rule.meta.id))?.module ??
+							resolvedModules()?.meta.find((m) => m.id.includes(rule.id))?.module ??
 							"Unknown module. You stumbled on a bug in inlang's source code. Please open an issue.",
-
 						// default to warning, see https://github.com/inlang/monorepo/issues/1254
-						lintLevel: settingsValue["messageLintRuleLevels"]?.[rule.meta.id] ?? "warning",
+						level: settingsValue["messageLintRuleLevels"]?.[rule.id] ?? "warning",
 					} satisfies InstalledMessageLintRule),
 			) satisfies Array<InstalledMessageLintRule>
 		}
@@ -147,9 +148,11 @@ export const loadProject = async (args: {
 		const installedPlugins = () => {
 			if (!resolvedModules()) return []
 			return resolvedModules()!.plugins.map((plugin) => ({
-				meta: plugin.meta,
+				id: plugin.id,
+				displayName: plugin.displayName,
+				description: plugin.description,
 				module:
-					resolvedModules()?.meta.find((m) => m.id.includes(plugin.meta.id))?.module ??
+					resolvedModules()?.meta.find((m) => m.id.includes(plugin.id))?.module ??
 					"Unknown module. You stumbled on a bug in inlang's source code. Please open an issue.",
 			})) satisfies Array<InstalledPlugin>
 		}
@@ -161,7 +164,7 @@ export const loadProject = async (args: {
 		const messagesQuery = createMessagesQuery(() => messages() || [])
 		const lintReportsQuery = createMessageLintReportsQuery(
 			messages,
-			settings,
+			settings as () => ProjectSettings,
 			installedMessageLintRules,
 			resolvedModules,
 		)

--- a/inlang/source-code/sdk/src/resolve-modules/message-lint-rules/resolveMessageLintRules.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/message-lint-rules/resolveMessageLintRules.ts
@@ -10,7 +10,7 @@ export const resolveMessageLintRules = (args: { messageLintRules: Array<MessageL
 	for (const rule of args.messageLintRules) {
 		if (Value.Check(MessageLintRule, rule) === false) {
 			result.errors.push(
-				new MessageLintRuleIsInvalidError(`Couldn't parse lint rule "${rule.meta.id}"`, {
+				new MessageLintRuleIsInvalidError(`Couldn't parse lint rule "${rule.id}"`, {
 					module: "not implemented",
 				}),
 			)

--- a/inlang/source-code/sdk/src/resolve-modules/plugins/errors.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/plugins/errors.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "@inlang/plugin"
 
 type PluginErrorOptions = {
-	plugin: Plugin["meta"]["id"]
+	plugin: Plugin["id"]
 } & Partial<Error>
 
 class PluginError extends Error {

--- a/inlang/source-code/sdk/src/resolve-modules/plugins/resolvePlugins.test.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/plugins/resolvePlugins.test.ts
@@ -15,17 +15,12 @@ import type { Plugin } from "@inlang/plugin"
 describe("generally", () => {
 	it("should return an error if a plugin uses an invalid id", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				// @ts-expect-error - invalid id
-				id: "no-namespace",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			// @ts-expect-error - invalid id
+			id: "no-namespace",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: () => undefined as any,
 			saveMessages: () => undefined as any,
-			addCustomApi() {
-				return {}
-			},
 		}
 
 		const resolved = await resolvePlugins({
@@ -39,11 +34,9 @@ describe("generally", () => {
 
 	it("should return an error if a plugin uses APIs that are not available", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.undefinedApi",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.undefinedApi",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			// @ts-expect-error the key is not available in type
 			nonExistentKey: {
 				nonexistentOptions: "value",
@@ -63,11 +56,9 @@ describe("generally", () => {
 
 	it("should not initialize a plugin that uses the 'inlang' namespace except for inlang whitelisted plugins", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.inlang.notWhitelisted",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.inlang.notWhitelisted",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: () => undefined as any,
 		}
 
@@ -84,11 +75,9 @@ describe("generally", () => {
 describe("loadMessages", () => {
 	it("should load messages from a local source", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.placeholder",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: async () => [{ id: "test", expressions: [], selectors: [], variants: [] }],
 		}
 
@@ -108,19 +97,15 @@ describe("loadMessages", () => {
 
 	it("should collect an error if function is defined twice in multiple plugins", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namepsace.loadMessagesFirst",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.loadMessagesFirst",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: async () => undefined as any,
 		}
 		const mockPlugin2: Plugin = {
-			meta: {
-				id: "plugin.namepsace.loadMessagesSecond",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.loadMessagesSecond",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: async () => undefined as any,
 		}
 
@@ -135,11 +120,9 @@ describe("loadMessages", () => {
 
 	it("should return an error if no plugin defines loadMessages", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namepsace.loadMessagesFirst",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.loadMessagesFirst",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			saveMessages: async () => undefined as any,
 		}
 
@@ -157,11 +140,9 @@ describe("loadMessages", () => {
 describe("saveMessages", () => {
 	it("should save messages to a local source", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.placeholder",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: async () => undefined as any,
 			saveMessages: async () => undefined as any,
 		}
@@ -177,19 +158,15 @@ describe("saveMessages", () => {
 
 	it("should collect an error if function is defined twice in multiple plugins", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namepsace.saveMessages",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.saveMessages",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			saveMessages: async () => undefined as any,
 		}
 		const mockPlugin2: Plugin = {
-			meta: {
-				id: "plugin.namepsace.saveMessages2",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.saveMessages2",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 
 			saveMessages: async () => undefined as any,
 		}
@@ -205,11 +182,9 @@ describe("saveMessages", () => {
 
 	it("should return an error if no plugin defines saveMessages", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namepsace.loadMessagesFirst",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.loadMessagesFirst",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			loadMessages: async () => undefined as any,
 		}
 
@@ -226,22 +201,18 @@ describe("saveMessages", () => {
 describe("detectedLanguageTags", () => {
 	it("should merge language tags from plugins", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namepsace.detectedLanguageTags",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.detectedLanguageTags",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			detectedLanguageTags: async () => ["de", "en"],
 			addCustomApi: () => {
 				return {}
 			},
 		}
 		const mockPlugin2: Plugin = {
-			meta: {
-				id: "plugin.namepsace.detectedLanguageTags2",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.detectedLanguageTags2",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			addCustomApi: () => {
 				return {}
 			},
@@ -261,11 +232,9 @@ describe("detectedLanguageTags", () => {
 describe("addCustomApi", () => {
 	it("it should resolve app specific api", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.placeholder",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 
 			addCustomApi: () => ({
 				"my-app": {
@@ -285,11 +254,9 @@ describe("addCustomApi", () => {
 
 	it("it should resolve multiple app specific apis", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.placeholder",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			addCustomApi: () => ({
 				"my-app-1": {
 					functionOfMyApp1: () => undefined as any,
@@ -300,11 +267,9 @@ describe("addCustomApi", () => {
 			}),
 		}
 		const mockPlugin2: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder2",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.placeholder2",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 
 			addCustomApi: () => ({
 				"my-app-3": {
@@ -326,11 +291,9 @@ describe("addCustomApi", () => {
 
 	it("it should throw an error if return value is not an object", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namespace.placeholder",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			// @ts-expect-error - invalid return type
 			addCustomApi: () => undefined,
 		}
@@ -346,11 +309,9 @@ describe("addCustomApi", () => {
 
 	it("it should throw an error if the passed options are not defined inside customApi", async () => {
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namepsace.placeholder",
-				description: { en: "My plugin description" },
-				displayName: { en: "My plugin" },
-			},
+			id: "plugin.namepsace.placeholder",
+			description: { en: "My plugin description" },
+			displayName: { en: "My plugin" },
 			addCustomApi: () => ({
 				"app.inlang.placeholder": {
 					messageReferenceMatcher: () => {

--- a/inlang/source-code/sdk/src/resolve-modules/plugins/resolvePlugins.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/plugins/resolvePlugins.ts
@@ -41,23 +41,23 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 		 */
 
 		// -- INVALID ID in META --
-		const hasInvalidId = errors.some((error) => error.path === "/meta/id")
+		const hasInvalidId = errors.some((error) => error.path === "/id")
 		if (hasInvalidId) {
 			result.errors.push(
 				new PluginHasInvalidIdError(
-					`Plugin ${plugin.meta.id} has an invalid id "${plugin.meta.id}". It must be kebap-case and contain a namespace like project.my-plugin.`,
-					{ plugin: plugin.meta.id },
+					`Plugin ${plugin.id} has an invalid id "${plugin.id}". It must be kebap-case and contain a namespace like project.my-plugin.`,
+					{ plugin: plugin.id },
 				),
 			)
 		}
 
 		// -- USES RESERVED NAMESPACE --
-		if (plugin.meta.id.includes("inlang") && !whitelistedPlugins.includes(plugin.meta.id)) {
+		if (plugin.id.includes("inlang") && !whitelistedPlugins.includes(plugin.id)) {
 			result.errors.push(
 				new PluginUsesReservedNamespaceError(
-					`Plugin ${plugin.meta.id} uses reserved namespace 'inlang'.`,
+					`Plugin ${plugin.id} uses reserved namespace 'inlang'.`,
 					{
-						plugin: plugin.meta.id,
+						plugin: plugin.id,
 					},
 				),
 			)
@@ -67,9 +67,9 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 		if (errors.length > 0) {
 			result.errors.push(
 				new PluginHasInvalidSchemaError(
-					`Plugin ${plugin.meta.id} uses an invalid schema. Please check the documentation for the correct Plugin type.`,
+					`Plugin ${plugin.id} uses an invalid schema. Please check the documentation for the correct Plugin type.`,
 					{
-						plugin: plugin.meta.id,
+						plugin: plugin.id,
 						cause: errors,
 					},
 				),
@@ -80,8 +80,8 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 		if (typeof plugin.loadMessages === "function" && result.data.loadMessages !== undefined) {
 			result.errors.push(
 				new PluginLoadMessagesFunctionAlreadyDefinedError(
-					`Plugin ${plugin.meta.id} defines the loadMessages function, but it was already defined by another plugin.`,
-					{ plugin: plugin.meta.id },
+					`Plugin ${plugin.id} defines the loadMessages function, but it was already defined by another plugin.`,
+					{ plugin: plugin.id },
 				),
 			)
 		}
@@ -89,8 +89,8 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 		if (typeof plugin.saveMessages === "function" && result.data.saveMessages !== undefined) {
 			result.errors.push(
 				new PluginSaveMessagesFunctionAlreadyDefinedError(
-					`Plugin ${plugin.meta.id} defines the saveMessages function, but it was already defined by another plugin.`,
-					{ plugin: plugin.meta.id },
+					`Plugin ${plugin.id} defines the saveMessages function, but it was already defined by another plugin.`,
+					{ plugin: plugin.id },
 				),
 			)
 		}
@@ -100,7 +100,7 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 			// TODO: why do we call this function 2 times (here for validation and later for retrieving the actual value)?
 			const { data: customApi, error } = tryCatch(() =>
 				plugin.addCustomApi!({
-					settings: args.settings?.[plugin.meta.id] ?? {},
+					settings: args.settings?.[plugin.id] ?? {},
 				}),
 			)
 			if (error) {
@@ -111,8 +111,8 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 			if (typeof customApi !== "object") {
 				result.errors.push(
 					new PluginReturnedInvalidCustomApiError(
-						`Plugin ${plugin.meta.id} defines the addCustomApi function, but it does not return an object.`,
-						{ plugin: plugin.meta.id, cause: error },
+						`Plugin ${plugin.id} defines the addCustomApi function, but it does not return an object.`,
+						{ plugin: plugin.id, cause: error },
 					),
 				)
 			}
@@ -131,7 +131,7 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 			result.data.loadMessages = (_args) =>
 				plugin.loadMessages!({
 					..._args,
-					settings: args.settings?.[plugin.meta.id] ?? {},
+					settings: args.settings?.[plugin.id] ?? {},
 					nodeishFs: args.nodeishFs,
 				})
 		}
@@ -140,14 +140,14 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 			result.data.saveMessages = (_args) =>
 				plugin.saveMessages!({
 					..._args,
-					settings: args.settings?.[plugin.meta.id] ?? {},
+					settings: args.settings?.[plugin.id] ?? {},
 					nodeishFs: args.nodeishFs,
 				})
 		}
 
 		if (typeof plugin.detectedLanguageTags === "function") {
 			const detectedLangugeTags = await plugin.detectedLanguageTags!({
-				settings: args.settings?.[plugin.meta.id] ?? {},
+				settings: args.settings?.[plugin.id] ?? {},
 				nodeishFs: args.nodeishFs,
 			})
 			result.data.detectedLanguageTags = [
@@ -158,7 +158,7 @@ export const resolvePlugins: ResolvePluginsFunction = async (args) => {
 		if (typeof plugin.addCustomApi === "function") {
 			const { data: customApi } = tryCatch(() =>
 				plugin.addCustomApi!({
-					settings: args.settings?.[plugin.meta.id] ?? {},
+					settings: args.settings?.[plugin.id] ?? {},
 				}),
 			)
 			if (customApi) {

--- a/inlang/source-code/sdk/src/resolve-modules/plugins/types.test.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/plugins/types.test.ts
@@ -6,14 +6,12 @@ import { Plugin } from "@inlang/plugin"
 
 describe("Plugin", () => {
 	test("meta.id should enforce plugin.namespace.* patterns", () => {
-		expectType<`plugin.${string}.${string}`>("" as Plugin["meta"]["id"])
+		expectType<`plugin.${string}.${string}`>("" as Plugin["id"])
 
 		const mockPlugin: Plugin = {
-			meta: {
-				id: "plugin.namespace.placeholder",
-				displayName: { en: "" },
-				description: { en: "" },
-			},
+			id: "plugin.namespace.placeholder",
+			displayName: { en: "" },
+			description: { en: "" },
 		}
 
 		const passCases = ["plugin.namespace.helloWorld", "plugin.namespace.i18n"]
@@ -24,14 +22,14 @@ describe("Plugin", () => {
 		]
 
 		for (const pass of passCases) {
-			mockPlugin.meta.id = pass as any
+			mockPlugin.id = pass as any
 
 			// @ts-ignore - type mismatch error. fix after refactor
 			expect(Value.Check(Plugin, mockPlugin)).toBe(true)
 		}
 
 		for (const fail of failCases) {
-			mockPlugin.meta.id = fail as any
+			mockPlugin.id = fail as any
 			// @ts-ignore - type mismatch error. fix after refactor
 			expect(Value.Check(Plugin, mockPlugin)).toBe(false)
 		}
@@ -49,7 +47,7 @@ describe("Plugin", () => {
 			const mergedSettings = { ...settings, [_case]: {} }
 			expect(Value.Check(ProjectSettings, mergedSettings)).toBe(true)
 			// @ts-ignore - type mismatch error. fix after refactor
-			expect(Value.Check(Plugin["properties"]["meta"]["properties"]["id"], _case)).toBe(true)
+			expect(Value.Check(Plugin["properties"]["id"], _case)).toBe(true)
 		}
 	})
 })

--- a/inlang/source-code/sdk/src/resolve-modules/plugins/types.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/plugins/types.ts
@@ -28,7 +28,7 @@ export type NodeishFilesystemSubset = Pick<
  */
 export type ResolvePluginsFunction = (args: {
 	plugins: Array<Plugin>
-	settings: Record<Plugin["meta"]["id"], JSONObject>
+	settings: Record<Plugin["id"], JSONObject>
 	nodeishFs: NodeishFilesystemSubset
 }) => Promise<{
 	data: ResolvedPluginApi

--- a/inlang/source-code/sdk/src/resolve-modules/resolveModules.test.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/resolveModules.test.ts
@@ -114,9 +114,7 @@ it("should return an error if a module does not export anything", async () => {
 		modules: ["https://myplugin.com/index.js"],
 	}
 
-	const _import = async () => ({
-		default: {},
-	})
+	const _import = async () => ({})
 
 	// Call the function
 	const resolved = await resolveModules({ settings, _import, nodeishFs: {} as any })

--- a/inlang/source-code/sdk/src/resolve-modules/resolveModules.test.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/resolveModules.test.ts
@@ -36,11 +36,9 @@ it("should return an error if a plugin cannot be imported", async () => {
 it("should resolve plugins and message lint rules successfully", async () => {
 	// Define mock data
 	const mockPlugin: Plugin = {
-		meta: {
-			id: "plugin.namespace.mock",
-			description: { en: "Mock plugin description" },
-			displayName: { en: "Mock Plugin" },
-		},
+		id: "plugin.namespace.mock",
+		description: { en: "Mock plugin description" },
+		displayName: { en: "Mock Plugin" },
 		loadMessages: () => undefined as any,
 		saveMessages: () => undefined as any,
 		addCustomApi: () => ({
@@ -51,12 +49,10 @@ it("should resolve plugins and message lint rules successfully", async () => {
 	}
 
 	const mockMessageLintRule: MessageLintRule = {
-		meta: {
-			id: "messageLintRule.namespace.mock",
-			description: { en: "Mock lint rule description" },
-			displayName: { en: "Mock Lint Rule" },
-		},
-		message: () => undefined,
+		id: "messageLintRule.namespace.mock",
+		description: { en: "Mock lint rule description" },
+		displayName: { en: "Mock Lint Rule" },
+		run: () => undefined,
 	}
 
 	const settings: ProjectSettings = {
@@ -83,11 +79,11 @@ it("should resolve plugins and message lint rules successfully", async () => {
 	// Assert results
 	expect(resolved.errors).toHaveLength(0)
 	// Check for the meta data of the plugin
-	expect(resolved.plugins.some((module) => module.meta.id === mockPlugin.meta.id)).toBeDefined()
+	expect(resolved.plugins.some((module) => module.id === mockPlugin.id)).toBeDefined()
 	// Check for the app specific api
 	expect(resolved.resolvedPluginApi["customApi"]?.["app.inlang.ideExtension"]).toBeDefined()
 	// Check for the lint rule
-	expect(resolved.messageLintRules[0]?.meta.id).toBe(mockMessageLintRule.meta.id)
+	expect(resolved.messageLintRules[0]?.id).toBe(mockMessageLintRule.id)
 })
 
 it("should return an error if a module cannot be imported", async () => {
@@ -111,7 +107,7 @@ it("should return an error if a module cannot be imported", async () => {
 	expect(resolved.errors[0]).toBeInstanceOf(ModuleImportError)
 })
 
-it("should return an error if a module does not export any plugins or lint rules", async () => {
+it("should return an error if a module does not export anything", async () => {
 	const settings: ProjectSettings = {
 		sourceLanguageTag: "en",
 		languageTags: ["de", "en"],
@@ -137,12 +133,10 @@ it("should return an error if a module exports an invalid plugin or lint rule", 
 	}
 	const _import = async () =>
 		({
+			// @ts-expect-error - invalid meta of a plugin
 			default: {
-				// @ts-expect-error - invalid meta of a plugin
-				meta: {
-					id: "plugin.namespace.mock",
-					description: { en: "Mock plugin description" },
-				},
+				id: "plugin.namespace.mock",
+				description: { en: "Mock plugin description" },
 			},
 		} satisfies InlangModule)
 

--- a/inlang/source-code/sdk/src/resolve-modules/resolveModules.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/resolveModules.ts
@@ -43,8 +43,8 @@ export const resolveModules: ResolveModuleFunction = async (args) => {
 			continue
 		}
 
-		// -- MODULE DOES NOT EXPORT PLUGINS OR LINT RULES --
-		if (importedModule.data?.default?.meta?.id === undefined) {
+		// -- MODULE DOES NOT EXPORT ANYTHING --
+		if (importedModule.data?.default === undefined) {
 			moduleErrors.push(
 				new ModuleHasNoExportsError(`Module "${module}" has no exports.`, {
 					module: module,
@@ -56,9 +56,11 @@ export const resolveModules: ResolveModuleFunction = async (args) => {
 		const isValidModule = ModuleCompiler.Check(importedModule.data)
 
 		if (isValidModule === false) {
-			const errors = [...ModuleCompiler.Errors(importedModule.data)]
+			const errors = [...ModuleCompiler.Errors(importedModule.data)].map(
+				(e) => `${e.path} ${e.message}`,
+			)
 			moduleErrors.push(
-				new ModuleExportIsInvalidError(`Module "${module}" is invalid: ` + errors, {
+				new ModuleExportIsInvalidError(`Module "${module}" is invalid: ` + errors.join("\n"), {
 					module: module,
 				}),
 			)
@@ -67,12 +69,12 @@ export const resolveModules: ResolveModuleFunction = async (args) => {
 
 		meta.push({
 			module: module,
-			id: importedModule.data.default.meta.id,
+			id: importedModule.data.default.id,
 		})
 
-		if (importedModule.data.default.meta.id.startsWith("plugin.")) {
+		if (importedModule.data.default.id.startsWith("plugin.")) {
 			allPlugins.push(importedModule.data.default as Plugin)
-		} else if (importedModule.data.default.meta.id.startsWith("messageLintRule.")) {
+		} else if (importedModule.data.default.id.startsWith("messageLintRule.")) {
 			allMessageLintRules.push(importedModule.data.default as MessageLintRule)
 		} else {
 			throw new Error(`Unimplemented module type. Must start with "plugin." or "messageLintRule.`)

--- a/inlang/source-code/sdk/src/resolve-modules/types.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/types.ts
@@ -39,7 +39,7 @@ export type ResolveModuleFunction = (args: {
 		/**
 		 * The resolved item id of the module.
 		 */
-		id: Plugin["meta"]["id"] | MessageLintRule["meta"]["id"]
+		id: Plugin["id"] | MessageLintRule["id"]
 	}>
 	/**
 	 * The resolved plugins.

--- a/inlang/source-code/templates/message-lint-rule/src/messageLintRule.ts
+++ b/inlang/source-code/templates/message-lint-rule/src/messageLintRule.ts
@@ -2,17 +2,15 @@ import { MessageLintRule } from "@inlang/sdk"
 import { id, displayName, description } from "../marketplace-manifest.json"
 
 export const messageLintRule: MessageLintRule = {
-	meta: {
-		id: id as MessageLintRule["meta"]["id"],
-		displayName,
-		description,
-	},
+	id: id as MessageLintRule["id"],
+	displayName,
+	description,
 	// implement lint rule here
-	message: ({ message, report, sourceLanguageTag }) => {
+	run: ({ message, report, settings }) => {
 		if (message.id.includes("-")) {
 			report({
 				messageId: message.id,
-				languageTag: sourceLanguageTag,
+				languageTag: settings.sourceLanguageTag,
 				body: "Message IDs should not contain dashes.",
 			})
 		}

--- a/inlang/source-code/templates/plugin/src/plugin.test.ts
+++ b/inlang/source-code/templates/plugin/src/plugin.test.ts
@@ -28,7 +28,7 @@ it("should return fake messages to illustrate how a plugin works", async () => {
 
 	expect(project.errors()).toEqual([])
 
-	expect(project.installed.plugins()[0]?.meta.id).toBe(pluginId)
+	expect(project.installed.plugins()[0]?.id).toBe(pluginId)
 
 	expect(project.query.messages.get({ where: { id: "this-is-a-test-message" } })).toBeDefined()
 })

--- a/inlang/source-code/templates/plugin/src/plugin.ts
+++ b/inlang/source-code/templates/plugin/src/plugin.ts
@@ -3,11 +3,9 @@ import { id, displayName, description } from "../marketplace-manifest.json"
 import { createMessage } from "@inlang/sdk/test-utilities"
 
 export const plugin: Plugin = {
-	meta: {
-		id: id as Plugin["meta"]["id"],
-		displayName,
-		description,
-	},
+	id: id as Plugin["id"],
+	displayName,
+	description,
 	loadMessages: async () => {
 		console.info("loadMessages called")
 		const fakeMessages = [

--- a/inlang/source-code/versioned-interfaces/message-lint-rule/package.json
+++ b/inlang/source-code/versioned-interfaces/message-lint-rule/package.json
@@ -22,9 +22,9 @@
 		"clean": "rm -rf ./dist ./.turbo ./node_modules"
 	},
 	"dependencies": {
-		"@inlang/json-types": "*",
-		"@inlang/message": "*",
 		"@inlang/language-tag": "*",
+		"@inlang/message": "*",
+		"@inlang/project-settings": "2.0.0",
 		"@inlang/translatable": "*"
 	},
 	"peerDependencies": {

--- a/inlang/source-code/versioned-interfaces/message-lint-rule/src/index.ts
+++ b/inlang/source-code/versioned-interfaces/message-lint-rule/src/index.ts
@@ -1,11 +1,1 @@
 export * from "./interface.js"
-
-/**
- * -------- RE-EXPORTS --------
- *
- * See https://github.com/inlang/monorepo/issues/1184.
- */
-
-export * from "@inlang/message"
-export * from "@inlang/language-tag"
-export * from "@inlang/translatable"

--- a/inlang/source-code/versioned-interfaces/message-lint-rule/src/interface.ts
+++ b/inlang/source-code/versioned-interfaces/message-lint-rule/src/interface.ts
@@ -1,31 +1,31 @@
 import type { Message } from "@inlang/message"
 import type { LanguageTag } from "@inlang/language-tag"
 import { Translatable } from "@inlang/translatable"
-import { Type, type Static, type TTemplateLiteral, type TLiteral } from "@sinclair/typebox"
-import type { JSONObject } from "@inlang/json-types"
+import { Type, type Static } from "@sinclair/typebox"
+import {
+	_MessageLintRuleId,
+	_MessageLintRuleLevel,
+	type ProjectSettings,
+} from "@inlang/project-settings"
 
 export type MessageLintLevel = Static<typeof MessageLintLevel>
-export const MessageLintLevel = Type.Union([Type.Literal("error"), Type.Literal("warning")])
+export const MessageLintLevel = _MessageLintRuleLevel
 
 /**
  * The basis of a lint report (required to contruct a lint report union type)
  */
 export type MessageLintReport = {
-	ruleId: MessageLintRule["meta"]["id"]
+	ruleId: MessageLintRule["id"]
 	messageId: Message["id"]
 	languageTag: LanguageTag
 	level: MessageLintLevel
 	body: Translatable<string>
 }
 
-export type MessageLintRule<LintRuleSettings extends JSONObject | any = any> = Static<
-	typeof MessageLintRule
-> & {
-	message: (args: {
+export type MessageLintRule = Static<typeof MessageLintRule> & {
+	run: (args: {
 		message: Message
-		sourceLanguageTag: LanguageTag
-		languageTags: LanguageTag[]
-		settings: LintRuleSettings
+		settings: ProjectSettings
 		report: (args: {
 			messageId: Message["id"]
 			languageTag: LanguageTag
@@ -34,18 +34,9 @@ export type MessageLintRule<LintRuleSettings extends JSONObject | any = any> = S
 	}) => MaybePromise<void>
 }
 export const MessageLintRule = Type.Object({
-	meta: Type.Object({
-		id: Type.String({
-			pattern: "^messageLintRule\\.([a-z][a-zA-Z0-9]*)\\.([a-z][a-zA-Z0-9]*(?:[A-Z][a-z0-9]*)*)$",
-			description: "The key must be conform to `messageLintRule.{namespace}.{id}` pattern.",
-			examples: [
-				"messageLintRule.namespace.patternInvalid",
-				"messageLintRule.namespace.missingTranslation",
-			],
-		}) as unknown as TTemplateLiteral<[TLiteral<`messageLintRule.${string}.${string}`>]>,
-		displayName: Translatable(Type.String()),
-		description: Translatable(Type.String()),
-	}),
+	id: _MessageLintRuleId,
+	displayName: Translatable(Type.String()),
+	description: Translatable(Type.String()),
 })
 
 /**

--- a/inlang/source-code/versioned-interfaces/plugin/package.json
+++ b/inlang/source-code/versioned-interfaces/plugin/package.json
@@ -22,11 +22,12 @@
 		"clean": "rm -rf ./dist ./.turbo ./node_modules"
 	},
 	"dependencies": {
-		"@lix-js/fs": "*",
 		"@inlang/json-types": "*",
-		"@inlang/message": "*",
 		"@inlang/language-tag": "*",
-		"@inlang/translatable": "*"
+		"@inlang/message": "*",
+		"@inlang/project-settings": "2.0.0",
+		"@inlang/translatable": "*",
+		"@lix-js/fs": "*"
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": "^0.31.0"

--- a/inlang/source-code/versioned-interfaces/plugin/src/interface.ts
+++ b/inlang/source-code/versioned-interfaces/plugin/src/interface.ts
@@ -72,14 +72,12 @@ export type Plugin<Settings extends JSONObject | unknown = unknown> = Omit<
 
 export const Plugin = Type.Object(
 	{
-		meta: Type.Object({
-			id: Type.String({
-				pattern: "^plugin\\.([a-z][a-zA-Z0-9]*)\\.([a-z][a-zA-Z0-9]*(?:[A-Z][a-z0-9]*)*)$",
-				examples: ["plugin.namespace.id"],
-			}) as unknown as TTemplateLiteral<[TLiteral<`plugin.${string}.${string}`>]>,
-			displayName: Translatable(Type.String()),
-			description: Translatable(Type.String()),
-		}),
+		id: Type.String({
+			pattern: "^plugin\\.([a-z][a-zA-Z0-9]*)\\.([a-z][a-zA-Z0-9]*(?:[A-Z][a-z0-9]*)*)$",
+			examples: ["plugin.namespace.id"],
+		}) as unknown as TTemplateLiteral<[TLiteral<`plugin.${string}.${string}`>]>,
+		displayName: Translatable(Type.String()),
+		description: Translatable(Type.String()),
 		loadMessages: Type.Optional(Type.Any()),
 		saveMessages: Type.Optional(Type.Any()),
 		detectedLanguageTags: Type.Optional(Type.Any()),

--- a/inlang/source-code/versioned-interfaces/project-settings/package.json
+++ b/inlang/source-code/versioned-interfaces/project-settings/package.json
@@ -24,7 +24,6 @@
 	},
 	"dependencies": {
 		"@inlang/json-types": "*",
-		"@inlang/message-lint-rule": "*",
 		"@inlang/language-tag": "*"
 	},
 	"devDependencies": {

--- a/inlang/source-code/versioned-interfaces/project-settings/src/index.ts
+++ b/inlang/source-code/versioned-interfaces/project-settings/src/index.ts
@@ -1,1 +1,7 @@
-export { ProjectSettings } from "./interface.js"
+export {
+	ProjectSettings,
+	// the types beneath are exported to avoid circular dependencies.
+	// use the types from the corresponding package directly instead.
+	_MessageLintRuleId,
+	_MessageLintRuleLevel,
+} from "./interface.js"

--- a/inlang/source-code/versioned-interfaces/project-settings/src/interface.ts
+++ b/inlang/source-code/versioned-interfaces/project-settings/src/interface.ts
@@ -1,14 +1,25 @@
 import { type Static, type TLiteral, type TTemplateLiteral, Type } from "@sinclair/typebox"
 import { LanguageTag } from "@inlang/language-tag"
-import { MessageLintLevel, MessageLintRule } from "@inlang/message-lint-rule"
-import { JSON, JSONObject } from "@inlang/json-types"
+import { JSON, type JSONObject } from "@inlang/json-types"
 
 /**
- * ---------------- UTILITY TYPES ----------------
+ * ---------------- AVOIDING CIRCULAR DEPENDENCIES ----------------
+ *
+ * The types beneath belong to other packages that depent on project settings
+ * and must therefore be declared here to avoid circular dependencies.
+ *
  */
 
-// workaround to get the id from a union type
-const MessageLintRuleId = MessageLintRule["properties"]["meta"]["properties"]["id"]
+export const _MessageLintRuleId = Type.String({
+	pattern: "^messageLintRule\\.([a-z][a-zA-Z0-9]*)\\.([a-z][a-zA-Z0-9]*(?:[A-Z][a-z0-9]*)*)$",
+	description: "The key must be conform to `messageLintRule.{namespace}.{id}` pattern.",
+	examples: [
+		"messageLintRule.namespace.patternInvalid",
+		"messageLintRule.namespace.missingTranslation",
+	],
+}) as unknown as TTemplateLiteral<[TLiteral<`messageLintRule.${string}.${string}`>]>
+
+export const _MessageLintRuleLevel = Type.Union([Type.Literal("error"), Type.Literal("warning")])
 
 /**
  * ---------------- Settings ----------------
@@ -55,7 +66,7 @@ const InternalSettings = Type.Object({
 		},
 	),
 	messageLintRuleLevels: Type.Optional(
-		Type.Record(MessageLintRuleId, MessageLintLevel, {
+		Type.Record(_MessageLintRuleId, _MessageLintRuleLevel, {
 			description: "The lint rule levels for messages.",
 			examples: [
 				{

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/Layout.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/Layout.tsx
@@ -189,7 +189,7 @@ export function Layout(props: { children: JSXElement }) {
 																	setFilteredMessageLintRules(
 																		project()
 																			?.installed.messageLintRules()
-																			.map((lintRule) => lintRule.meta.id) ?? [],
+																			.map((lintRule) => lintRule.id) ?? [],
 																	)
 																}
 																addFilter(filter.name)
@@ -486,7 +486,7 @@ function LintFilter(props: { clearFunction: any }) {
 						setFilteredMessageLintRules(
 							project()
 								?.installed.messageLintRules()
-								.map((lintRule) => lintRule.meta.id) ?? [],
+								.map((lintRule) => lintRule.id) ?? [],
 						)
 					}
 				>
@@ -509,10 +509,10 @@ function LintFilter(props: { clearFunction: any }) {
 					}
 				>
 					{(lintRule) => (
-						<sl-option prop:value={lintRule.meta.id}>
-							{typeof lintRule.meta.displayName === "object"
-								? lintRule.meta.displayName.en
-								: lintRule.meta.displayName}
+						<sl-option prop:value={lintRule.id}>
+							{typeof lintRule.displayName === "object"
+								? lintRule.displayName.en
+								: lintRule.displayName}
 						</sl-option>
 					)}
 				</For>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
@@ -102,8 +102,8 @@ type EditorStateSchema = {
 	/**
 	 * Filtered lint rules.
 	 */
-	filteredMessageLintRules: () => MessageLintRule["meta"]["id"][]
-	setFilteredMessageLintRules: Setter<MessageLintRule["meta"]["id"][]>
+	filteredMessageLintRules: () => MessageLintRule["id"][]
+	setFilteredMessageLintRules: Setter<MessageLintRule["id"][]>
 
 	/**
 	 * Expose lix errors that happen wihle opening the repository
@@ -189,8 +189,8 @@ export function EditorStateProvider(props: { children: JSXElement }) {
 	})
 
 	const [filteredMessageLintRules, setFilteredMessageLintRules] = createSignal<
-		MessageLintRule["meta"]["id"][]
-	>(params.getAll("lint") as MessageLintRule["meta"]["id"][])
+		MessageLintRule["id"][]
+	>(params.getAll("lint") as MessageLintRule["id"][])
 	createEffect(() => {
 		setSearchParams({ key: "lint", value: filteredMessageLintRules() })
 	})

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Listheader.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Listheader.tsx
@@ -30,7 +30,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 	} = useEditorState()
 
 	const getLintSummary = createMemo(() => {
-		const summary: Record<MessageLintRule["meta"]["id"], number> = {}
+		const summary: Record<MessageLintRule["id"], number> = {}
 		for (const report of project()?.query.messageLintReports.getAll() || []) {
 			if (
 				filteredMessageLintRules().length === 0 ||
@@ -42,12 +42,10 @@ export const ListHeader = (props: ListHeaderProps) => {
 		return summary
 	})
 
-	const getLintRule = (
-		lintRuleId: MessageLintRule["meta"]["id"],
-	): InstalledMessageLintRule | undefined =>
+	const getLintRule = (lintRuleId: MessageLintRule["id"]): InstalledMessageLintRule | undefined =>
 		project()
 			?.installed.messageLintRules()
-			.find((rule) => rule.meta.id === lintRuleId)
+			.find((rule) => rule.id === lintRuleId)
 
 	return (
 		<div class="h-14 w-full bg-background border border-surface-3 rounded-t-md flex items-center px-4 justify-between">
@@ -70,7 +68,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 			</Show>
 
 			<div class="flex gap-2">
-				<For each={Object.keys(getLintSummary()) as MessageLintRule["meta"]["id"][]}>
+				<For each={Object.keys(getLintSummary()) as MessageLintRule["id"][]}>
 					{(lintRule) => (
 						<Show when={getLintSummary()[lintRule] !== 0}>
 							<TourHintWrapper
@@ -84,10 +82,10 @@ export const ListHeader = (props: ListHeaderProps) => {
 							>
 								<sl-tooltip
 									prop:content={
-										typeof getLintRule(lintRule)?.meta.description === "object"
+										typeof getLintRule(lintRule)?.description === "object"
 											? // @ts-ignore
-											  getLintRule(lintRule)?.meta.description.en
-											: getLintRule(lintRule)?.meta.description
+											  getLintRule(lintRule)?.description.en
+											: getLintRule(lintRule)?.description
 									}
 									prop:placement="bottom"
 									prop:trigger="hover"
@@ -98,7 +96,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 										prop:size="small"
 										class={
 											filteredMessageLintRules()?.includes(lintRule || "")
-												? getLintRule(lintRule)!.lintLevel === "warning"
+												? getLintRule(lintRule)!.level === "warning"
 													? "ring-warning/20 ring-1 rounded"
 													: "ring-danger/20 ring-1 rounded"
 												: ""
@@ -125,7 +123,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 											<div class="-ml-[4px] h-5 rounded">
 												<div
 													class={
-														getLintRule(lintRule)?.lintLevel === "warning"
+														getLintRule(lintRule)?.level === "warning"
 															? " text-focus-warning bg-warning/20 h-full px-2 rounded flex items-center justify-center"
 															: "text-focus-danger bg-danger/20 h-full px-2 rounded flex items-center justify-center"
 													}
@@ -135,10 +133,10 @@ export const ListHeader = (props: ListHeaderProps) => {
 											</div>
 
 											<div class="text-xs text-on-surface-variant font-medium">
-												{typeof getLintRule(lintRule)?.meta.displayName === "object"
+												{typeof getLintRule(lintRule)?.displayName === "object"
 													? // @ts-ignore
-													  getLintRule(lintRule)?.meta.displayName.en
-													: getLintRule(lintRule)?.meta.displayName}
+													  getLintRule(lintRule)?.displayName.en
+													: getLintRule(lintRule)?.displayName}
 											</div>
 										</div>
 									</sl-button>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
@@ -308,7 +308,7 @@ export function PatternEditor(props: {
 			if (report.messageId === props.message.id && report.languageTag === props.languageTag) {
 				const messageLintRuleName = project()
 					?.installed.messageLintRules()
-					.find((rule) => rule.meta.id === report.ruleId)?.meta.displayName
+					.find((rule) => rule.id === report.ruleId)?.displayName
 				notifications.push({
 					notificationTitle:
 						typeof messageLintRuleName === "object"

--- a/package-lock.json
+++ b/package-lock.json
@@ -52741,9 +52741,9 @@
 			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@inlang/json-types": "*",
 				"@inlang/language-tag": "*",
 				"@inlang/message": "*",
+				"@inlang/project-settings": "2.0.0",
 				"@inlang/translatable": "*"
 			},
 			"devDependencies": {
@@ -55922,6 +55922,7 @@
 				"@inlang/json-types": "*",
 				"@inlang/language-tag": "*",
 				"@inlang/message": "*",
+				"@inlang/project-settings": "2.0.0",
 				"@inlang/translatable": "*",
 				"@lix-js/fs": "*"
 			},
@@ -57532,8 +57533,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@inlang/json-types": "*",
-				"@inlang/language-tag": "*",
-				"@inlang/message-lint-rule": "*"
+				"@inlang/language-tag": "*"
 			},
 			"devDependencies": {
 				"tsd": "0.28.1",


### PR DESCRIPTION
```diff
- plugin.meta.id
+ plugin.id

- messageLintRule.meta.id
+ messageLintRule.id

```

**why**

- simplify system by avoiding nesting
- nesting was introduced by the wrong assumption that meta needs to be extracted. 