### PR TITLE
add: project error log to machine translate cmd

### DIFF
--- a/.changeset/dry-hornets-boil.md
+++ b/.changeset/dry-hornets-boil.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": minor
+---
+
+add better error handling

--- a/inlang/source-code/cli/src/commands/lint/index.ts
+++ b/inlang/source-code/cli/src/commands/lint/index.ts
@@ -20,9 +20,20 @@ export const lint = new Command()
 /* @ts-ignore */
 export async function lintCommandAction(args: { project: InlangProject; logger: any }) {
 	try {
+		for (const error of args.project.errors()) {
+			// @ts-ignore
+			if (error.cause) {
+				// @ts-ignore
+				log.error(`❌ ${error} (${error.cause})`)
+			} else {
+				log.error(`❌ ${error}`)
+			}
+			return
+		}
+
 		if (args.project.installed.messageLintRules().length === 0) {
 			args.logger.error(
-				`No message lint rules are installed. Visit the marketplace to install lint rules https://inlang.com/marketplace .`,
+				`❌ No message lint rules are installed. Visit the marketplace to install lint rules https://inlang.com/marketplace .`,
 			)
 			return
 		}

--- a/inlang/source-code/cli/src/commands/machine/translate.ts
+++ b/inlang/source-code/cli/src/commands/machine/translate.ts
@@ -51,6 +51,18 @@ export async function translateCommandAction(args: { project: InlangProject }) {
 			log.error(`❌ No inlang config found, please add a project.inlang.json file`)
 			return
 		}
+
+		for (const error of args.project.errors()) {
+			// @ts-ignore
+			if (error.cause) {
+				// @ts-ignore
+				log.error(`❌ ${error} (${error.cause})`)
+			} else {
+				log.error(`❌ ${error}`)
+			}
+			return
+		}
+
 		const sourceLanguageTag = projectConfig.sourceLanguageTag
 		// Get languages to translate to with the reference language removed
 

--- a/inlang/source-code/cli/src/commands/project/validate.ts
+++ b/inlang/source-code/cli/src/commands/project/validate.ts
@@ -14,12 +14,12 @@ export async function validateCommandAction() {
 		// Get the config
 		const { error } = await getInlangProject()
 		if (error) {
-			log.error(error)
+			log.error(`❌ ${error} (${error.message})`)
 			return
 		}
 
 		log.success("🎉 Inlang config is valid!")
 	} catch (error) {
-		log.error(error)
+		log.error(`❌ ${error}`)
 	}
 }

--- a/inlang/source-code/rpc/src/functions/machineTranslateMessage.ts
+++ b/inlang/source-code/rpc/src/functions/machineTranslateMessage.ts
@@ -19,7 +19,7 @@ Promise<Result<Message, string>> {
 				!args.sourceLanguageTag ||
 				!args.message.variants.some((variant) => variant.languageTag === args.sourceLanguageTag)
 			) {
-				throw new Error("Source Language configuration missing")
+				throw new Error("Source language configuration missing")
 			}
 			for (const variant of args.message.variants.filter(
 				(variant) => variant.languageTag === args.sourceLanguageTag,


### PR DESCRIPTION
@felixhaeberle Feel free to merge.

**Changes:**
- add error logging in the machine translate command

**Suggestion:**
With almost all CLI commands, we have to handle errors at some point because otherwise, the actions will not work as expected. These should always be checked before executing the actual command.