### PR TITLE
improve tailwind css with RTL compatible classes

### DIFF
--- a/inlang/source-code/end-to-end-tests/inlang-nextjs/app/page.tsx
+++ b/inlang/source-code/end-to-end-tests/inlang-nextjs/app/page.tsx
@@ -4,11 +4,11 @@ export default function Home() {
 	return (
 		<main className="flex min-h-screen flex-col items-center justify-between p-24">
 			<div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
-				<p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
+				<p className="fixed start-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
 					Get started by editing&nbsp;
 					<code className="font-mono font-bold">app/page.tsx</code>
 				</p>
-				<div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:h-auto lg:w-auto lg:bg-none">
+				<div className="fixed bottom-0 start-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:h-auto lg:w-auto lg:bg-none">
 					<a
 						className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
 						href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"

--- a/inlang/source-code/website/lang/en.json
+++ b/inlang/source-code/website/lang/en.json
@@ -119,7 +119,7 @@
 			"description": "We're sad to see you go. If you have any feedback, please let us know on our"
 		},
 		"title": "Newsletter",
-		"placeholder": "Enter your email ...",
+		"placeholder": "Enter your email",
 		"button": "Subscribe",
 		"error": {
 			"invalidEmail": "Please enter a valid email address.",

--- a/inlang/source-code/website/src/components/notification/InlineNotification.tsx
+++ b/inlang/source-code/website/src/components/notification/InlineNotification.tsx
@@ -14,9 +14,9 @@ export function InlineNotification(props: {
 }) {
 	return (
 		<div
-			class={`flex rounded gap-2 items-center px-4 py-2 bg-surface-variant text-on-surface border-l-4 border-l-${props.variant}`}
+			class={`flex rounded gap-2 items-center px-4 py-2 bg-surface-variant text-on-surface border-s-4 border-s-${props.variant}`}
 		>
-			<Icon name={props.variant} class={`text-${props.variant} mr-1`} />
+			<Icon name={props.variant} class={`text-${props.variant} me-1`} />
 			<div class="flex gap-1.5">
 				<h3 class="font-medium">{props.title}</h3>
 				<Show when={props.message}>

--- a/inlang/source-code/website/src/pages/Layout.tsx
+++ b/inlang/source-code/website/src/pages/Layout.tsx
@@ -112,7 +112,7 @@ function Header(props: { landingpage?: boolean }) {
 						<div class="flex">
 							<a href={getLocale() + "/"} class="flex items-center w-fit">
 								<img class="h-9 w-9" src="/favicon/safari-pinned-tab.svg" alt="Company Logo" />
-								<span class="self-center pl-2 text-left font-semibold text-surface-900">
+								<span class="self-center ps-2 text-left font-semibold text-surface-900">
 									inlang
 								</span>
 							</a>
@@ -182,7 +182,7 @@ function Header(props: { landingpage?: boolean }) {
 						</div>
 						{/* MobileNavbar includes the Navigation for the Documentations sites  */}
 						<Show when={mobileMenuIsOpen()}>
-							<ol class="space-y-1 relativ w-full min-h-full pt-3 pl-[10px] overflow">
+							<ol class="space-y-1 relativ w-full min-h-full pt-3 ps-[10px] overflow">
 								<For each={getLinks()}>
 									{(link) => (
 										<sl-tree>
@@ -280,7 +280,7 @@ const Footer = (props: { isLandingPage: boolean }) => {
 					<div class="w-full md:w-1/4 xl:px-10 flex flex-row items-center sm:items-start md:flex-col justify-between">
 						<a href="/" class="flex items-center w-fit">
 							<img class="h-9 w-9" src="/favicon/safari-pinned-tab.svg" alt="Company Logo" />
-							<span class="self-center pl-2 text-left font-semibold text-surface-900">inlang</span>
+							<span class="self-center ps-2 text-left font-semibold text-surface-900">inlang</span>
 						</a>
 					</div>
 					<div class="w-full sm:w-1/3 md:w-1/4 xl:px-10 flex flex-col pt-2">

--- a/inlang/source-code/website/src/pages/blog/@id/Navigation.tsx
+++ b/inlang/source-code/website/src/pages/blog/@id/Navigation.tsx
@@ -9,7 +9,7 @@
 // }) {
 // 	return (
 // 		<nav class="sticky top-[3.5rem] h-[calc(100vh-4.5rem)] overflow-y-auto  md:block w-full hidden">
-// 			<ul role="list" class="divide-y divide-outline pr-4 min-h-full ">
+// 			<ul role="list" class="divide-y divide-outline pe-4 min-h-full ">
 // 				<For each={tablesections}>
 // 					{(section) => (
 // 						<li class="py-3">

--- a/inlang/source-code/website/src/pages/documentation/EditButton.tsx
+++ b/inlang/source-code/website/src/pages/documentation/EditButton.tsx
@@ -12,7 +12,7 @@ export function EditButton(props: EditButtonProps) {
 				class="text-info/80 hover:text-info/100 text-sm font-semibold flex items-center"
 				target="_blank"
 			>
-				<EditOutline class="inline-block mr-2" />
+				<EditOutline class="inline-block me-2" />
 				Edit on GitHub
 			</a>
 		</div>

--- a/inlang/source-code/website/src/pages/documentation/Feedback.tsx
+++ b/inlang/source-code/website/src/pages/documentation/Feedback.tsx
@@ -25,7 +25,7 @@ export function Feedback() {
 	return (
 		<div class="relative flex justify-center items-center pt-2 pb-8 sm:pt-10 sm:pb-8">
 			<div class="flex border border-surface-1 py-1 px-3 rounded-full items-center">
-				<p class="text-sm text-info pr-2">Was this helpful?</p>
+				<p class="text-sm text-info pe-2">Was this helpful?</p>
 				<For each={feedbackEmojis}>
 					{(emoji) => (
 						<button

--- a/inlang/source-code/website/src/pages/documentation/index.page.tsx
+++ b/inlang/source-code/website/src/pages/documentation/index.page.tsx
@@ -69,12 +69,12 @@ export function Page(props: PageProps) {
           hacking the left margins to apply bg-surface-2 with 100rem 
               (tested on an ultrawide monitor, works!) 
           */}
-					<div class="hidden md:block h-full -ml-[100rem] pl-[100rem] border-r-[1px] border-surface-2">
+					<div class="hidden md:block h-full -ms-[100rem] ps-[100rem] border-e-[1px] border-surface-2">
 						<nav class="sticky top-12 max-h-[96vh] overflow-y-scroll overflow-scrollbar">
 							{/* `Show` is a hotfix when client side rendering loaded this page
 							 * filteredTableContents is not available on the client.
 							 */}
-							<div class="py-14 pr-8">
+							<div class="py-14 pe-8">
 								<Show when={tableOfContents && props.markdown}>
 									<NavbarCommon
 										tableOfContents={tableOfContents}

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/Layout.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/Layout.tsx
@@ -134,7 +134,7 @@ export function Layout(props: { children: JSXElement }) {
 					<BranchMenu />
 				</div>
 				<div class="flex justify-between gap-2 py-5 sticky top-[72px] z-30 bg-background">
-					<div class="absolute -left-2 w-[calc(100%_+_16px)] h-full -translate-y-5 bg-background" />
+					<div class="absolute -start-2 w-[calc(100%_+_16px)] h-full -translate-y-5 bg-background" />
 					<div class="flex z-20 justify-between gap-2 items-center">
 						<Show when={project()}>
 							<For each={filterOptions()}>
@@ -160,7 +160,7 @@ export function Layout(props: { children: JSXElement }) {
 										prop:size="small"
 										onClick={() => {
 											setFilteredLanguageTags(
-												setFilteredLanguageTags(project()?.settings()?.languageTags || []),
+												setFilteredLanguageTags(project()?.settings()?.languageTags || [])
 											)
 											setFilteredMessageLintRules([])
 											setSelectedFilters([])
@@ -196,14 +196,14 @@ export function Layout(props: { children: JSXElement }) {
 																	setFilteredMessageLintRules(
 																		project()
 																			?.installed.messageLintRules()
-																			.map((lintRule) => lintRule.id) ?? [],
+																			.map((lintRule) => lintRule.id) ?? []
 																	)
 																}
 																addFilter(filter.name)
 															}}
 															class="flex gap-2 items-center w-full"
 														>
-															<div slot="prefix" class="-ml-2 mr-2">
+															<div slot="prefix" class="-ms-2 me-2">
 																{filter.icon}
 															</div>
 															{filter.name}
@@ -219,7 +219,7 @@ export function Layout(props: { children: JSXElement }) {
 					</div>
 					<div class="flex gap-2">
 						<SearchInput
-							placeholder="Search ..."
+							placeholder="Search all messages"
 							handleChange={(text: string) => setTextSearch(text)}
 						/>
 						<sl-button
@@ -238,7 +238,7 @@ export function Layout(props: { children: JSXElement }) {
 				prop:open={addLanguageModalOpen()}
 				on:sl-after-hide={() => setAddLanguageModalOpen(false)}
 			>
-				<p class="text-xs pb-4 -mt-4 pr-8">
+				<p class="text-xs pb-4 -mt-4 pe-8">
 					You can add a language to the ressource, by providing a unique tag. By doing that inlang
 					is creating a new language file and commits it to the local repository instance.
 				</p>
@@ -375,7 +375,7 @@ function LanguageFilter(props: { clearFunction: any }) {
 				}}
 				class="border-0 focus:ring-background/100 p-0 m-0 text-sm"
 			>
-				<div class="flex items-center gap-2 ml-1" slot="prefix">
+				<div class="flex items-center gap-2 ms-1" slot="prefix">
 					<p class="flex-grow-0 flex-shrink-0 text-sm font-medium text-left text-on-surface-variant">
 						Language
 					</p>
@@ -459,7 +459,7 @@ function LintFilter(props: { clearFunction: any }) {
 			}}
 			class="border-0 focus:ring-background/100 p-0 m-0 text-sm"
 		>
-			<div class={"flex items-center gap-2 ml-1 mr-0"} slot="prefix">
+			<div class={"flex items-center gap-2 ms-1 me-0"} slot="prefix">
 				<p class="flex-grow-0 flex-shrink-0 text-sm font-medium text-left text-on-surface-variant">
 					Lint
 				</p>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Gitfloat.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Gitfloat.tsx
@@ -244,7 +244,7 @@ export const Gitfloat = () => {
 			<div class="gitfloat z-30 sticky start-1/2 -translate-x-[150px] bottom-8 w-[300px] my-16 animate-slideIn">
 				<TourHintWrapper
 					currentId={tourStep()}
-					position="top-right"
+					position="top-end"
 					offset={{ x: 0, y: 60 }}
 					isVisible={
 						(tourStep() === "github-login" || tourStep() === "fork-repository") &&

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Gitfloat.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Gitfloat.tsx
@@ -241,7 +241,7 @@ export const Gitfloat = () => {
 
 	return (
 		<>
-			<div class="gitfloat z-30 sticky left-1/2 -translate-x-[150px] bottom-8 w-[300px] my-16 animate-slideIn">
+			<div class="gitfloat z-30 sticky start-1/2 -translate-x-[150px] bottom-8 w-[300px] my-16 animate-slideIn">
 				<TourHintWrapper
 					currentId={tourStep()}
 					position="top-right"
@@ -256,7 +256,7 @@ export const Gitfloat = () => {
 				>
 					<div class="w-full flex justify-start items-center rounded-lg bg-inverted-surface shadow-xl ">
 						<Show when={localStorage.user}>
-							<div class="flex justify-start items-center self-stretch flex-grow-0 flex-shrink-0 relative gap-2 p-1.5 rounded-tl-lg rounded-bl-lg border-t-0 border-r border-b-0 border-l-0 border-background/10">
+							<div class="flex justify-start items-center self-stretch flex-grow-0 flex-shrink-0 relative gap-2 p-1.5 rounded-se--lg rounded-es-lg border-t-0 border-r border-b-0 border-s-0 border-background/10">
 								<img
 									src={localStorage.user?.avatarUrl}
 									alt="user avatar"
@@ -266,8 +266,8 @@ export const Gitfloat = () => {
 						</Show>
 						<div
 							class={
-								"flex justify-start items-center self-stretch flex-grow relative gap-2 pr-1.5 py-1.5 " +
-								(gitState() === "pullrequest" ? "pl-1.5" : "pl-3")
+								"flex justify-start items-center self-stretch flex-grow relative gap-2 pe-1.5 py-1.5 " +
+								(gitState() === "pullrequest" ? "ps-1.5" : "ps-3")
 							}
 						>
 							<p

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Listheader.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Listheader.tsx
@@ -79,7 +79,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 						<Show when={getLintSummary()[lintRule] !== 0}>
 							<TourHintWrapper
 								currentId="missing-translation-rule"
-								position="bottom-right"
+								position="bottom-end"
 								offset={{ x: 0, y: 40 }}
 								isVisible={
 									lintRule === "messageLintRule.inlang.missingTranslation" &&
@@ -110,7 +110,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 										onClick={() => {
 											if (filteredMessageLintRules().includes(lintRule)) {
 												setFilteredMessageLintRules(
-													filteredMessageLintRules().filter((id) => id !== lintRule),
+													filteredMessageLintRules().filter((id) => id !== lintRule)
 												)
 											} else {
 												setFilteredMessageLintRules([lintRule])
@@ -154,7 +154,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 				<Show when={project()?.installed.messageLintRules().length === 0}>
 					<TourHintWrapper
 						currentId="missing-lint-rules"
-						position="bottom-right"
+						position="bottom-end"
 						offset={{ x: 0, y: 40 }}
 						isVisible={tourStep() === "missing-lint-rules"}
 					>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Listheader.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Listheader.tsx
@@ -126,7 +126,7 @@ export const ListHeader = (props: ListHeaderProps) => {
 													: "lint-summary"
 											}
 										>
-											<div class="-ml-[4px] h-5 rounded">
+											<div class="-ms-[4px] h-5 rounded">
 												<div
 													class={
 														getLintRule(lintRule)?.level === "warning"

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Notification/NotificationPopup.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Notification/NotificationPopup.tsx
@@ -16,7 +16,7 @@ export const NotificationPopup = (props: NotificationPopupProps) => {
 		<div
 			class={
 				"z-30 absolute w-[300px] bg-inverted-surface rounded shadow-xl transition duration-20 " +
-				(props.position === "bottom-right" ? "right-0 pointer-events-none " : "left-0 ") +
+				(props.position === "bottom-right" ? "end-0 pointer-events-none " : "start-0 ") +
 				(props.open() ? "opacity-100" : "translate-y-0.5 opacity-0")
 			}
 			style={
@@ -58,7 +58,7 @@ export const NotificationPopup = (props: NotificationPopupProps) => {
 				{props.handleClose && (
 					<button
 						onClick={() => props.handleClose && props.handleClose()}
-						class="flex justify-center items-center h-8 w-8 mr-4 hover:bg-background/10 text-on-inverted-surface rounded-md"
+						class="flex justify-center items-center h-8 w-8 me-4 hover:bg-background/10 text-on-inverted-surface rounded-md"
 					>
 						<CloseIcon />
 					</button>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Notification/TourHintWrapper.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/Notification/TourHintWrapper.tsx
@@ -8,7 +8,7 @@ export type TourStepId =
 	| "missing-translation-rule"
 	| "textfield"
 
-export type Position = "top-right" | "top-left" | "bottom-right" | "bottom-left"
+export type Position = "top-end" | "top-start" | "bottom-end" | "bottom-start"
 
 type OffsetType = { x: number; y: number }
 
@@ -56,33 +56,33 @@ const TourStepWrapper = (props: {
 }) => {
 	const getPosition = (position: Position, offset: OffsetType) => {
 		switch (position) {
-			case "top-right":
+			case "top-end":
 				return {
-					top: "unset",
-					right: offset.x.toString() + "px",
+					insetBlockStart: "unset",
+					insetInlineEnd: offset.x.toString() + "px",
 					bottom: offset.y.toString() + "px",
-					left: "unset",
+					insetInlineStart: "unset",
 				}
-			case "top-left":
+			case "top-start":
 				return {
-					top: "unset",
-					right: "unset",
-					bottom: offset.y.toString() + "px",
-					left: offset.x.toString() + "px",
+					insetBlockStart: "unset",
+					insetInlineEnd: "unset",
+					insetBlockEnd: offset.y.toString() + "px",
+					insetInlineStart: offset.x.toString() + "px",
 				}
-			case "bottom-right":
+			case "bottom-end":
 				return {
-					top: offset.y.toString() + "px",
-					right: offset.x.toString() + "px",
-					buttom: "unset",
-					left: "unset",
+					insetBlockStart: offset.y.toString() + "px",
+					insetInlineEnd: offset.x.toString() + "px",
+					insetBlockEnd: "unset",
+					insetInlineStart: "unset",
 				}
-			case "bottom-left":
+			case "bottom-start":
 				return {
-					top: offset.y.toString() + "px",
-					right: "unset",
-					bottom: "unset",
-					left: offset.x.toString() + "px",
+					insetBlockStart: offset.y.toString() + "px",
+					insetInlineEnd: "unset",
+					insetBlockEnd: "unset",
+					insetInlineStart: offset.x.toString() + "px",
 				}
 		}
 	}
@@ -92,28 +92,28 @@ const TourStepWrapper = (props: {
 			class={
 				"absolute p-3 w-[300px] z-20 rounded-lg bg-inverted-surface shadow-xl text-on-inverted-surface text-xs  " +
 				(props.isVisible && localStorage.isFirstUse ? "" : " hidden") +
-				(props.position === "top-right" || props.position === "top-left"
+				(props.position === "top-end" || props.position === "top-start"
 					? " animate-fadeInTop"
 					: " animate-fadeInBottom")
 			}
 			style={getPosition(props.position, props.offset) as JSX.CSSProperties}
 		>
-			{(props.position === "bottom-right" || props.position === "bottom-left") && (
+			{(props.position === "bottom-end" || props.position === "bottom-start") && (
 				<div class="relative w-full h-0 text-inverted-surface">
 					<div
 						class={
-							(props.position === "bottom-left" ? "justify-start" : "justify-end") +
+							(props.position === "bottom-start" ? "justify-start" : "justify-end") +
 							" before:content-['▲'] h-2 flex items-center px-2 -translate-y-5 "
 						}
 					/>
 				</div>
 			)}
 			{props.children}
-			{(props.position === "top-right" || props.position === "top-left") && (
+			{(props.position === "top-end" || props.position === "top-start") && (
 				<div class="relative w-full h-0 text-inverted-surface">
 					<div
 						class={
-							(props.position === "top-left" ? "justify-start" : "justify-end") +
+							(props.position === "top-start" ? "justify-start" : "justify-end") +
 							" before:content-['▼'] h-2 flex items-center px-2 translate-y-3"
 						}
 					/>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
@@ -458,7 +458,7 @@ export function PatternEditor(props: {
 						height="24"
 						viewBox="0 0 24 24"
 						fill="none"
-						class="text-hover-primary mr-1"
+						class="text-hover-primary me-1"
 					>
 						<path
 							d="M4 12L9 17L19.5 6.5"

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/helper/editorSetup.ts
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/helper/editorSetup.ts
@@ -39,7 +39,7 @@ export const getEditorConfig = (
 			}),
 			Placeholder.configure({
 				emptyEditorClass: "is-editor-empty",
-				placeholder: "Enter translation...",
+				placeholder: "Enter translation",
 			}),
 			History.configure({
 				depth: 10,

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
@@ -200,7 +200,7 @@ function RepositoryDoesNotExistOrNotAuthorizedCard(args: { code: number }) {
 				<h2 class="font-semibold pt-12">
 					Repo does not exist or you don't have sufficient access rights.
 				</h2>
-				<ul class="pt-8 list-disc pl-4">
+				<ul class="pt-8 list-disc ps-4">
 					<li>
 						Make sure that you the repository owner{" "}
 						<code class="bg-secondary-container py-1 px-1.5 rounded text-on-secondary-container">

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
@@ -137,7 +137,7 @@ function TheActualPage() {
 						<ListHeader ids={project()?.query.messages.includedMessageIds() || []} />
 						<TourHintWrapper
 							currentId="textfield"
-							position="bottom-left"
+							position="bottom-start"
 							offset={{ x: 110, y: 144 }}
 							isVisible={tourStep() === "textfield"}
 						>

--- a/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
+++ b/inlang/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
@@ -91,7 +91,7 @@ function TheActualPage() {
 							{/* use font-size to change the spinner size    */}
 							<sl-spinner class="text-4xl" />
 						</div>
-						<p class="text-lg font-medium">Cloning large repositories can take a few minutes...</p>
+						<p class="text-lg font-medium">Cloning large repositories can take a few seconds...</p>
 						<br />
 						<p class="max-w-lg">
 							TL;DR you are currently cloning a real git repo, in the browser, on top of a virtual

--- a/inlang/source-code/website/src/pages/editor/index.page.tsx
+++ b/inlang/source-code/website/src/pages/editor/index.page.tsx
@@ -72,7 +72,7 @@ export function Page() {
 					>
 						<div
 							class={
-								"pl-5 pr-2 gap-2 relative z-10 flex items-center w-full border border-surface-200 bg-background rounded-lg transition-all " +
+								"ps-5 pe-2 gap-2 relative z-10 flex items-center w-full border border-surface-200 bg-background rounded-lg transition-all " +
 								(!isValidUrl() && input().length > 0
 									? "focus-within:border-danger"
 									: "focus-within:border-primary")
@@ -83,7 +83,7 @@ export function Page() {
 									"active:outline-0 focus:outline-0 focus:ring-0 border-0 h-14 grow placeholder:text-surface-500 placeholder:font-normal placeholder:text-base " +
 									(!isValidUrl() && input().length > 0 ? "text-danger" : "text-surface-800")
 								}
-								placeholder="Enter repository url ..."
+								placeholder="Enter repository url"
 								onInput={(event) => {
 									// @ts-ignore
 									setInput(event.target.value)
@@ -95,7 +95,7 @@ export function Page() {
 								on:sl-change={() => (isValidUrl() ? navigateToEditor : undefined)}
 							/>
 							{!isValidUrl() && input().length > 0 && (
-								<p class="text-xs text-danger font-medium pr-1 max-sm:hidden">
+								<p class="text-xs text-danger font-medium pe-1 max-sm:hidden">
 									Please enter a valid URL
 								</p>
 							)}
@@ -119,7 +119,7 @@ export function Page() {
 									"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 								transition: "all .3s ease-in-out",
 							}}
-							class="absolute bg-on-background top-0 left-0 w-full h-full opacity-10 blur-3xl group-hover:opacity-50 group-focus-within:opacity-50"
+							class="absolute bg-on-background top-0 start-0 w-full h-full opacity-10 blur-3xl group-hover:opacity-50 group-focus-within:opacity-50"
 						/>
 						<div
 							style={{
@@ -127,7 +127,7 @@ export function Page() {
 									"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 								transition: "all .3s ease-in-out",
 							}}
-							class="absolute bg-on-background top-0 left-0 w-full h-full opacity-5 blur-xl group-hover:opacity-15 group-focus-within:opacity-15"
+							class="absolute bg-on-background top-0 start-0 w-full h-full opacity-5 blur-xl group-hover:opacity-15 group-focus-within:opacity-15"
 						/>
 						<div
 							style={{
@@ -135,7 +135,7 @@ export function Page() {
 									"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 								transition: "all .3s ease-in-out",
 							}}
-							class="absolute bg-on-background top-0 left-0 w-full h-full opacity-10 blur-sm group-hover:opacity-25 group-focus-within:opacity-25"
+							class="absolute bg-on-background top-0 start-0 w-full h-full opacity-10 blur-sm group-hover:opacity-25 group-focus-within:opacity-25"
 						/>
 					</form>
 

--- a/inlang/source-code/website/src/pages/index/Hero.tsx
+++ b/inlang/source-code/website/src/pages/index/Hero.tsx
@@ -1,6 +1,6 @@
 import IconGithub from "~icons/cib/github"
 import CibGit from "~icons/cib/git"
-import MaterialSymbolsArrowRightAltRounded from "~icons/material-symbols/arrow-right-alt-rounded"
+import MaterialSymbolsArrowRightAltRounded from "~icons/material-symbols/arrow-end-alt-rounded"
 
 export function Hero() {
 	return (
@@ -29,7 +29,7 @@ export function Hero() {
 							<span class="inline-block">
 								git
 								{/* custom git color */}
-								<CibGit class="text-[#F54D27] inline pl-2 md:pl-3" />
+								<CibGit class="text-[#F54D27] inline ps-2 md:ps-3" />
 							</span>
 						</span>
 					</span>

--- a/inlang/source-code/website/src/pages/index/components/FeatureGitTitle.tsx
+++ b/inlang/source-code/website/src/pages/index/components/FeatureGitTitle.tsx
@@ -10,14 +10,14 @@ export const FeatureGitTitle = (props: FeatureGitTitleProps) => {
 			<h2 class={"text-3xl font-semibold " + "text-" + props.titleColor}>{props.title}</h2>
 			<div
 				class={
-					"absolute top-[calc(50%_-_22px)] rounded-full opacity-20 h-11 w-11 -ml-[61px] " +
+					"absolute top-[calc(50%_-_22px)] rounded-full opacity-20 h-11 w-11 -ms-[61px] " +
 					"bg-" +
 					props.circleColor
 				}
 			/>
 			<div
 				class={
-					"absolute top-[calc(50%_-_8px)] rounded-full border-2 bg-background h-4 w-4 -ml-[47px] " +
+					"absolute top-[calc(50%_-_8px)] rounded-full border-2 bg-background h-4 w-4 -ms-[47px] " +
 					"border-" +
 					props.circleColor
 				}

--- a/inlang/source-code/website/src/pages/index/components/sectionLayout.tsx
+++ b/inlang/source-code/website/src/pages/index/components/sectionLayout.tsx
@@ -27,7 +27,7 @@ export const SectionLayout = (props: SectionLayoutProps) => {
 		<div class={"w-full " + bgColor(props.type)}>
 			<div class={"relative " + landingpageGrid}>
 				{props.showLines && (
-					<div class={"invisible xl:visible absolute top-0 left-0 h-full w-full z-0 "}>
+					<div class={"invisible xl:visible absolute top-0 start-0 h-full w-full z-0 "}>
 						<div class="flex w-full h-full justify-between mx-auto">
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />

--- a/inlang/source-code/website/src/pages/index/sections/01-hero/index.tsx
+++ b/inlang/source-code/website/src/pages/index/sections/01-hero/index.tsx
@@ -14,7 +14,7 @@ const Hero = () => {
 		<SectionLayout showLines={true} type="lightGrey">
 			<div class="w-full flex pt-4 md:pt-16 flex-col xl:flex-row">
 				<div class="w-full xl:w-1/2 flex flex-col gap-8 px-6 md:px-10 py-16 md:pt-16 md:pb-32">
-					<h1 class="text-[40px] leading-tight md:text-6xl font-bold text-surface-900 pr-16 tracking-tight">
+					<h1 class="text-[40px] leading-tight md:text-6xl font-bold text-surface-900 pe-16 tracking-tight">
 						<p class="bg-clip-text text-[rgba(0,0,0,0)] bg-gradient-to-tl from-[#F1D9FF] via-hover-primary to-[#3B82F6]">
 							{`${t("landing.hero.keyword")} `}
 						</p>
@@ -56,9 +56,9 @@ const Hero = () => {
 						</div>
 					</div>
 				</div>
-				<div class="relative w-full xl:w-1/2 xl:-ml-[8px]">
+				<div class="relative w-full xl:w-1/2 xl:-ms-[8px]">
 					<div class="w-[2px] h-full absolute bg-hover-primary mx-10 xl:mx-[7px] z-2" />
-					<div class="w-auto h-full relative z-3 ml-[35px] xl:ml-0">
+					<div class="w-auto h-full relative z-3 ms-[35px] xl:ms-0">
 						<KeyVisual />
 					</div>
 				</div>

--- a/inlang/source-code/website/src/pages/index/sections/02-integration/index.tsx
+++ b/inlang/source-code/website/src/pages/index/sections/02-integration/index.tsx
@@ -23,7 +23,7 @@ const Integration = () => {
 	return (
 		<SectionLayout showLines={true} type="white">
 			<div class="relative">
-				<div class="hidden xl:block absolute w-[2px] bg-gradient-to-b from-hover-primary to-transparent h-24 left-1/2 -translate-x-1/2" />
+				<div class="hidden xl:block absolute w-[2px] bg-gradient-to-b from-hover-primary to-transparent h-24 start-1/2 -translate-x-1/2" />
 				<div class="flex flex-col items-center gap-12 py-16 overflow-hidden">
 					<div class="relative flex flex-row items-center gap-1 lg:gap-4 py-16">
 						<div class="z-10 opacity-40 w-16 h-16 flex justify-center items-center bg-surface-1 rounded-full border border-surface-2">
@@ -49,7 +49,7 @@ const Integration = () => {
 									stroke="currentColor"
 									xmlns="http://www.w3.org/2000/svg"
 									preserveAspectRatio="none"
-									class="absolute center-x -mt-[1px] left-1/2 transform -translate-x-1/2 top-full text-surface-800"
+									class="absolute center-x -mt-[1px] start-1/2 transform -translate-x-1/2 top-full text-surface-800"
 								>
 									<path d="M7 6L2 1H12L7 6Z" />
 								</svg>
@@ -62,7 +62,7 @@ const Integration = () => {
 						<div class="z-10 opacity-40 w-16 h-16 flex justify-center items-center bg-surface-1 rounded-full border border-surface-2">
 							<Vuejs size={28} startColor="#434343" endColor="#959595" />
 						</div>
-						<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+						<div class="absolute top-1/2 start-1/2 -translate-x-1/2 -translate-y-1/2">
 							<div class="animate-ripple w-32 h-32 bg-primary-on-inverted-container/50 border border-primary/5 rounded-full" />
 						</div>
 					</div>

--- a/inlang/source-code/website/src/pages/index/sections/03-config/index.tsx
+++ b/inlang/source-code/website/src/pages/index/sections/03-config/index.tsx
@@ -131,7 +131,7 @@ const ConfigPage = () => {
 									</Show>
 								</div>
 								<p class="text-md text-outline-variant sm:leading-7">{card.description}</p>
-								<ul class="items-center list-disc pl-4 pt-2">
+								<ul class="items-center list-disc ps-4 pt-2">
 									<For each={card.benefit}>
 										{(benefit) => <li class="text-sm text-outline-variant pt-2">{benefit}</li>}
 									</For>
@@ -194,21 +194,21 @@ const ConfigPage = () => {
 							background:
 								"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 						}}
-						class="absolute bg-on-background top-0 left-0 w-full h-full opacity-100 blur-3xl"
+						class="absolute bg-on-background top-0 start-0 w-full h-full opacity-100 blur-3xl"
 					/>
 					<div
 						style={{
 							background:
 								"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 						}}
-						class="absolute bg-on-background top-0 left-0 w-full h-full opacity-30 blur-xl"
+						class="absolute bg-on-background top-0 start-0 w-full h-full opacity-30 blur-xl"
 					/>
 					<div
 						style={{
 							background:
 								"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 						}}
-						class="absolute bg-on-background top-0 left-0 w-full h-full opacity-50 blur-sm"
+						class="absolute bg-on-background top-0 start-0 w-full h-full opacity-50 blur-sm"
 					/>
 				</a>
 			</div>
@@ -252,15 +252,15 @@ const ConfigPage = () => {
 					href={getLocale() + "/documentation/manually-create-project"}
 					class="w-full lg:w-fit overflow-x-scroll sm:overflow-x-hidden relative flex flex-col gap-2 bg-gradient-to-b from-inverted-surface to-surface-700 text-on-inverted-surface py-3 rounded-lg shadow-lg group"
 				>
-					<div class="absolute top-5 left-6 flex gap-2">
+					<div class="absolute top-5 start-6 flex gap-2">
 						<div class="w-3 h-3 bg-surface-600 rounded-full" />
 						<div class="w-3 h-3 bg-surface-600 rounded-full" />
 						<div class="w-3 h-3 bg-surface-600 rounded-full" />
 					</div>
-					<pre class="text-surface-400 leading-relaxed pl-12 sm:pl-0 w-full text-center transition duration-200 group-hover:text-primary-on-inverted-container">
+					<pre class="text-surface-400 leading-relaxed ps-12 sm:ps-0 w-full text-center transition duration-200 group-hover:text-primary-on-inverted-container">
 						project.inlang.json
 					</pre>
-					<div class="flex flex-col gap-1 px-8 py-4 pr-16">
+					<div class="flex flex-col gap-1 px-8 py-4 pe-16">
 						<For each={code}>
 							{(line, index) => (
 								<div class="flex gap-8 items-center text-xs sm:text-sm">

--- a/inlang/source-code/website/src/pages/index/sections/04-pricing/index.tsx
+++ b/inlang/source-code/website/src/pages/index/sections/04-pricing/index.tsx
@@ -18,8 +18,8 @@ const Pricing = () => {
 						{t("landing.pricing.description")}
 					</p>
 				</div>
-				<div class="w-full lg:w-[calc((100%_-_40px)_/_2)] flex items-end lg:pl-4">
-					<div class="h-full w-[55%] rounded-2xl rounded-br-none flex flex-col p-6 lg:p-8 gap-4 bg-gradient-to-b from-hover-primary/70 to-hover-primary/30">
+				<div class="w-full lg:w-[calc((100%_-_40px)_/_2)] flex items-end lg:ps-4">
+					<div class="h-full w-[55%] rounded-2xl rounded-ee-none flex flex-col p-6 lg:p-8 gap-4 bg-gradient-to-b from-hover-primary/70 to-hover-primary/30">
 						<p class="h-7 flex items-center px-3 rounded-full bg-background/50 w-fit text-surface-600 text-sm">
 							{t("landing.pricing.free.name")}
 						</p>
@@ -30,7 +30,7 @@ const Pricing = () => {
 							{t("landing.pricing.free.amount")}
 						</p>
 					</div>
-					<div class="h-[80%] w-[45%] rounded-2xl rounded-l-none flex flex-col p-6 lg:p-8 gap-4 bg-surface-1 border border-surface-2">
+					<div class="h-[80%] w-[45%] rounded-2xl rounded-s-none flex flex-col p-6 lg:p-8 gap-4 bg-surface-1 border border-surface-2">
 						<p class="h-7 flex items-center px-3 rounded-full bg-surface-500/10 w-fit text-surface-600 text-sm">
 							{t("landing.pricing.paid.name")}
 						</p>

--- a/inlang/source-code/website/src/pages/index/sections/06-getStarted/index.tsx
+++ b/inlang/source-code/website/src/pages/index/sections/06-getStarted/index.tsx
@@ -41,21 +41,21 @@ const GetStarted = () => {
 										background:
 											"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 									}}
-									class="absolute z-0 bg-on-background top-0 left-0 w-full h-full opacity-60 blur-3xl"
+									class="absolute z-0 bg-on-background top-0 start-0 w-full h-full opacity-60 blur-3xl"
 								/>
 								<div
 									style={{
 										background:
 											"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 									}}
-									class="absolute z-0 bg-on-background top-0 left-0 w-full h-full opacity-40 blur-xl"
+									class="absolute z-0 bg-on-background top-0 start-0 w-full h-full opacity-40 blur-xl"
 								/>
 								<div
 									style={{
 										background:
 											"linear-gradient(91.55deg, #51cbe0 2.95%, #5f98f3 52.23%, #bba0f8 99.17%)",
 									}}
-									class="absolute z-0 bg-on-background top-0 left-0 w-full h-full opacity-80 blur-sm"
+									class="absolute z-0 bg-on-background top-0 start-0 w-full h-full opacity-80 blur-sm"
 								/>
 							</button>
 						</a>

--- a/inlang/source-code/website/src/pages/install/index.page.tsx
+++ b/inlang/source-code/website/src/pages/install/index.page.tsx
@@ -277,7 +277,7 @@ function ShowProgress() {
 			{/* Big loading spinner */}
 			<div class="relative h-24 w-24 animate-spin mb-4">
 				<div class="h-full w-full bg-background border-primary border-4 rounded-full" />
-				<div class="h-1/2 w-1/2 absolute top-0 left-0 z-5 bg-background" />
+				<div class="h-1/2 w-1/2 absolute top-0 start-0 z-5 bg-background" />
 			</div>
 			<div class="flex flex-col justify-center gap-4 items-center">
 				<h2 class="text-[24px] leading-tight md:text-2xl font-semibold text-center">

--- a/inlang/source-code/website/src/pages/marketplace/404.page.tsx
+++ b/inlang/source-code/website/src/pages/marketplace/404.page.tsx
@@ -10,7 +10,7 @@ export function Page() {
 			<Meta name="robots" content="noindex" />
 			<Layout>
 				<div class="relative max-w-screen-xl w-full mx-auto bg-background">
-					<div class="invisible xl:visible absolute top-0 left-0 h-full w-full z-0">
+					<div class="invisible xl:visible absolute top-0 start-0 h-full w-full z-0">
 						<div class="flex w-full h-full justify-between mx-auto items-end">
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />
@@ -28,7 +28,7 @@ export function Page() {
 								Seems like the item you are looking for does not exist. This is a bug? Please report
 								it on our
 								<a
-									class="text-primary hover:text-hover-primary font-semibold ml-1.5"
+									class="text-primary hover:text-hover-primary font-semibold ms-1.5"
 									href="https://discord.gg/gdMPPWy57R"
 									target="_blank"
 								>
@@ -43,7 +43,7 @@ export function Page() {
 						<div class="w-full h-screen relative">
 							<div class="flex flex-col w-full h-full justify-end items-center">
 								<div class="h-full w-[2px] bg-gradient-to-t from-surface-100 to-hover-primary relative z-0">
-									<div class="w-full flex justify-center h-full z-3 ml-0">
+									<div class="w-full flex justify-center h-full z-3 ms-0">
 										<div class="text-hover-primary bg-[#FFF] z-10 flex justify-center items-center text-center mx-auto h-12 w-12 rounded-full bg-white border-2 border-hover-primary absolute -top-6">
 											<div class="w-0.5 rounded-full h-3/4 rotate-45 absolute bg-hover-primary" />
 											<div class="w-0.5 rounded-full h-3/4 -rotate-45 absolute bg-hover-primary" />

--- a/inlang/source-code/website/src/pages/marketplace/Select.tsx
+++ b/inlang/source-code/website/src/pages/marketplace/Select.tsx
@@ -118,13 +118,13 @@ export function ScrollFloat(props: { packages: Accessor<string[]> }) {
 	return (
 		<div
 			class={
-				"z-30 sticky left-1/2 -translate-x-[150px] bottom-8 w-[300px] my-16 opacity-0 transition-all " +
+				"z-30 sticky start-1/2 -translate-x-[150px] bottom-8 w-[300px] my-16 opacity-0 transition-all " +
 				(scroll() > 200 && props.packages().length > 0
 					? "animate-slideIn opacity-100"
 					: "animate-slideOut opacity-0")
 			}
 		>
-			<div class="w-full flex justify-between items-center rounded-lg bg-inverted-surface shadow-xl p-1.5 pl-3 text-background text-xs gap-1.5 font-medium">
+			<div class="w-full flex justify-between items-center rounded-lg bg-inverted-surface shadow-xl p-1.5 ps-3 text-background text-xs gap-1.5 font-medium">
 				{props.packages().length > 1 ? "You've choosen packages" : "You've choosen a package"}
 				<sl-button
 					prop:size="small"

--- a/inlang/source-code/website/src/pages/marketplace/index.page.tsx
+++ b/inlang/source-code/website/src/pages/marketplace/index.page.tsx
@@ -103,7 +103,7 @@ const Gallery = () => {
 									<Chip
 										text={typeOfIdToTitle(item.id)}
 										color={colorForTypeOf(item.id)}
-										customClasses="absolute right-4 top-4 z-5 backdrop-filter backdrop-blur-sm text-xs"
+										customClasses="absolute end-4 top-4 z-5 backdrop-filter backdrop-blur-sm text-xs"
 									/>
 									<Show when={!item.gallery}>
 										<Show
@@ -266,12 +266,12 @@ const Tags = () => {
 				class={
 					"gap-2 relative py-1.5 rounded-full cursor-pointer border border-solid text-sm capitalize hover:opacity-90 transition-all duration-100 flex items-center " +
 					(selectedCategories().includes("app")
-						? "bg-surface-800 text-background border-surface-800 pl-7 pr-3"
+						? "bg-surface-800 text-background border-surface-800 ps-7 pe-3"
 						: "bg-background text-surface-600 border-surface-200 px-3 hover:border-surface-400")
 				}
 			>
 				<Show when={selectedCategories().includes("app")}>
-					<Check class="w-4 h-4 absolute left-2" />
+					<Check class="w-4 h-4 absolute start-2" />
 				</Show>
 				<p class="m-0">Apps</p>
 			</div>
@@ -280,12 +280,12 @@ const Tags = () => {
 				class={
 					"gap-2 relative py-1.5 rounded-full cursor-pointer border border-solid text-sm capitalize hover:opacity-90 transition-all duration-100 flex items-center " +
 					(selectedCategories().includes("library")
-						? "bg-surface-800 text-background border-surface-800 pl-7 pr-3"
+						? "bg-surface-800 text-background border-surface-800 ps-7 pe-3"
 						: "bg-background text-surface-600 border-surface-200 px-3 hover:border-surface-400")
 				}
 			>
 				<Show when={selectedCategories().includes("library")}>
-					<Check class="w-4 h-4 absolute left-2" />
+					<Check class="w-4 h-4 absolute start-2" />
 				</Show>
 				<p class="m-0">Libraries</p>
 			</div>
@@ -294,12 +294,12 @@ const Tags = () => {
 				class={
 					"gap-2 relative py-1.5 rounded-full cursor-pointer border border-solid text-sm capitalize hover:opacity-90 transition-all duration-100 flex items-center " +
 					(selectedCategories().includes("messageLintRule")
-						? "bg-surface-800 text-background border-surface-800 pl-7 pr-3"
+						? "bg-surface-800 text-background border-surface-800 ps-7 pe-3"
 						: "bg-background text-surface-600 border-surface-200 px-3 hover:border-surface-400")
 				}
 			>
 				<Show when={selectedCategories().includes("messageLintRule")}>
-					<Check class="w-4 h-4 absolute left-2" />
+					<Check class="w-4 h-4 absolute start-2" />
 				</Show>
 				<p class="m-0">Lint Rules</p>
 			</div>
@@ -308,12 +308,12 @@ const Tags = () => {
 				class={
 					"gap-2 relative py-1.5 rounded-full cursor-pointer border border-solid text-sm capitalize hover:opacity-90 transition-all duration-100 flex items-center " +
 					(selectedCategories().includes("plugin")
-						? "bg-surface-800 text-background border-surface-800 pl-7 pr-3"
+						? "bg-surface-800 text-background border-surface-800 ps-7 pe-3"
 						: "bg-background text-surface-600 border-surface-200 px-3 hover:border-surface-400")
 				}
 			>
 				<Show when={selectedCategories().includes("plugin")}>
-					<Check class="w-4 h-4 absolute left-2" />
+					<Check class="w-4 h-4 absolute start-2" />
 				</Show>
 				<p class="m-0">Plugins</p>
 			</div>

--- a/inlang/source-code/website/src/pages/newsletter/index.page.tsx
+++ b/inlang/source-code/website/src/pages/newsletter/index.page.tsx
@@ -21,7 +21,7 @@ export function Page() {
 			<Meta name="robots" content="noindex" />
 			<Layout>
 				<div class="relative max-w-screen-xl w-full mx-auto bg-background">
-					<div class="invisible xl:visible absolute top-0 left-0 h-full w-full z-0">
+					<div class="invisible xl:visible absolute top-0 start-0 h-full w-full z-0">
 						<div class="flex w-full h-full justify-between mx-auto items-end">
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />

--- a/inlang/source-code/website/src/pages/newsletter/unsubscribed.page.tsx
+++ b/inlang/source-code/website/src/pages/newsletter/unsubscribed.page.tsx
@@ -20,7 +20,7 @@ export function Page() {
 			<Meta name="robots" content="noindex" />
 			<Layout>
 				<div class="relative max-w-screen-xl w-full mx-auto bg-background">
-					<div class="invisible xl:visible absolute top-0 left-0 h-full w-full z-0">
+					<div class="invisible xl:visible absolute top-0 start-0 h-full w-full z-0">
 						<div class="flex w-full h-full justify-between mx-auto items-end">
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />
 							<div class="h-full w-[2px] bg-surface-400 opacity-[7%]" />
@@ -37,7 +37,7 @@ export function Page() {
 							<p class="text-lg text-surface-600 leading-relaxed mx-auto text-center">
 								{t("newsletter.unsubscribed.description")}
 								<a
-									class="text-primary hover:text-hover-primary font-semibold ml-1.5"
+									class="text-primary hover:text-hover-primary font-semibold ms-1.5"
 									href="https://discord.gg/gdMPPWy57R"
 									target="_blank"
 								>
@@ -49,7 +49,7 @@ export function Page() {
 						<div class="w-full h-screen relative">
 							<div class="flex flex-col w-full h-full justify-end items-center">
 								<div class="h-full w-[2px] bg-gradient-to-t from-surface-100 to-hover-primary relative z-0">
-									<div class="w-full flex justify-center h-full z-3 ml-0">
+									<div class="w-full flex justify-center h-full z-3 ms-0">
 										<div class="text-hover-primary bg-[#FFF] z-10 flex justify-center items-center text-center mx-auto h-12 w-12 rounded-full bg-white border-2 border-hover-primary absolute -top-6">
 											<div class="w-0.5 rounded-full h-3/4 rotate-45 absolute bg-hover-primary" />
 											<div class="w-0.5 rounded-full h-3/4 -rotate-45 absolute bg-hover-primary" />

--- a/inlang/source-code/website/src/renderer/app.css
+++ b/inlang/source-code/website/src/renderer/app.css
@@ -175,7 +175,7 @@ sl-select::part(tags) {
 	font-size: 12px;
 	line-height: 140%;
 	font-weight: 500;
-	margin-left: 0;
+	margin-inline-start: 0;
 }
 
 sl-select::part(tags) {
@@ -186,13 +186,13 @@ sl-select::part(tags) {
 }
 
 sl-select::part(expand-icon) {
-	margin-left: 8px;
+	margin-inline-start: 8px;
 	width: 9px;
 	height: 9px;
 }
 
 sl-option::part(checked-icon) {
-	padding-right: 12px;
+	padding-inline-end: 12px;
 }
 
 sl-option::part(base) {
@@ -263,7 +263,6 @@ sl-menu {
 .ProseMirror p.is-editor-empty:first-child::before {
 	color: #adb5bd;
 	content: attr(data-placeholder);
-	float: left;
 	height: 0;
 	pointer-events: none;
 }


### PR DESCRIPTION
@inlang/team this PR aims to improve our current usage of tailwind css classes ("left" and "right") and replaces them with the "start" & "end" logical counterparts (called logical properties).

This change allows RTL users to have our UI displayed correctly & is no further maintenance burden for us. Please use whenever possible the correct "start" & "end" alternatives & ulimately ban "right" & "left" from your CSS box model thinking.

Thanksyy <3

More on logical properties & why we should use them: 
https://www.bram.us/2019/09/19/css-logical-properties-and-values-the-next-step-of-css-evolution/