### PR TITLE
update paraglide parser

### DIFF
--- a/.changeset/odd-ladybugs-film.md
+++ b/.changeset/odd-ladybugs-film.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-paraglide-js": minor
+---
+
+update paraglide parser

--- a/inlang/source-code/paraglide/paraglide-js-plugin/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-plugin/package.json
@@ -24,13 +24,13 @@
 		"@inlang/sdk": "*"
 	},
 	"devDependencies": {
-		"@lix-js/fs": "*",
 		"@inlang/cli": "*",
+		"@lix-js/fs": "*",
 		"@size-limit/preset-small-lib": "^8.2.4",
 		"@types/parsimmon": "1.10.6",
 		"@vitest/coverage-v8": "^0.33.0",
-		"patch-package": "6.5.1",
 		"parsimmon": "^1.18.1",
+		"patch-package": "6.5.1",
 		"typescript": "^5.1.3",
 		"vitest": "0.33.0"
 	}

--- a/inlang/source-code/paraglide/paraglide-js-plugin/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-plugin/src/ideExtension/messageReferenceMatchers.test.ts
@@ -160,6 +160,41 @@ describe("Paraglide Message Parser", () => {
 		])
 	})
 
+	it("should match the m function with an object and the arguments a function call", () => {
+		const sourceCode = `
+		import * as m from "@inlang/paraglide-js/example/messages";
+		m.helloWorld({args1: someFunction(), args2: otherFunction(), args3: "some string"});
+		`
+		const result = parse(sourceCode)
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 86 },
+				},
+			},
+		])
+	})
+
+	// it should match the m function which do have function chaining
+	it("should match the m function which do have function chaining", () => {
+		const sourceCode = `
+		import * as m from "@inlang/paraglide-js/example/messages";
+		m.helloWorld().someFunction().someOtherFunction();
+		`
+		const result = parse(sourceCode)
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 17 },
+				},
+			},
+		])
+	}) 
+
 	it("should match if m is defined before the reference to paraglide", () => {
 		const sourceCode = `
 		m.helloWorld();

--- a/inlang/source-code/paraglide/paraglide-js-plugin/src/ideExtension/messageReferenceMatchers.ts
+++ b/inlang/source-code/paraglide/paraglide-js-plugin/src/ideExtension/messageReferenceMatchers.ts
@@ -29,7 +29,7 @@ const createParser = () => {
 				Parsimmon.index, // start position of the message id
 				Parsimmon.regex(/[^(]*/), // message id
 				Parsimmon.index, // end position of the message id
-				Parsimmon.regex(/\([^)]*\)/), // function arguments
+				Parsimmon.regex(/\((?:[^()]|\([^()]*\))*\)/), // function arguments
 				(_, __, start, messageId, end, args) => {
 					return {
 						messageId: `${messageId}`,


### PR DESCRIPTION
update paraglide parser to catch such cases:

`m.helloWorld({args1: someFunction(), args2: otherFunction(), args3: "some string"});`

and 

`m.helloWorld().someFunction().someOtherFunction();`