### PR TITLE
Change return type of `extractMessageOptions`

### DIFF
--- a/.changeset/thick-eels-hang.md
+++ b/.changeset/thick-eels-hang.md
@@ -1,0 +1,9 @@
+---
+"@inlang/plugin": minor
+"@inlang/plugin-m-function-matcher": minor
+"@inlang/plugin-t-function-matcher": minor
+"@inlang/plugin-i18next": minor
+"vs-code-extension": minor
+---
+
+change return type of extractMessageOptions

--- a/inlang/source-code/ide-extension/src/commands/extractMessage.ts
+++ b/inlang/source-code/ide-extension/src/commands/extractMessage.ts
@@ -52,18 +52,19 @@ export const extractMessageCommand = {
 				return acc
 			}
 			return [...acc, option.callback({ messageId, selection: messageValue })]
-		}, [] as string[])
+		}, [] as { messageId: string; messageReplacement: string }[])
+
+		const messageReplacements = preparedExtractOptions.map(
+			({ messageReplacement }) => messageReplacement
+		)
 
 		const preparedExtractOption = await window.showQuickPick(
-			[...preparedExtractOptions, "How to edit these replacement options?"],
+			[...messageReplacements, "How to edit these replacement options?"],
 			{ title: "Replace highlighted text with:" }
 		)
 		if (preparedExtractOption === undefined) {
 			return
-		} else if (
-			preparedExtractOption ===
-			"How to edit these replacement options? See `extractMessageOptions`."
-		) {
+		} else if (preparedExtractOption === "How to edit these replacement options?") {
 			// TODO #152
 			return env.openExternal(
 				Uri.parse(
@@ -72,12 +73,16 @@ export const extractMessageCommand = {
 			)
 		}
 
-		if (preparedExtractOption === undefined) {
+		const selectedExtractOption = preparedExtractOptions.find(
+			({ messageReplacement }) => messageReplacement === preparedExtractOption
+		)
+
+		if (selectedExtractOption === undefined) {
 			return msg("Couldn't find choosen extract option.", "warn", "notification")
 		}
 
 		const message: Message = {
-			id: messageId,
+			id: selectedExtractOption.messageId,
 			selectors: [],
 			variants: [
 				{

--- a/inlang/source-code/plugins/i18next/src/ideExtension/config.ts
+++ b/inlang/source-code/plugins/i18next/src/ideExtension/config.ts
@@ -13,7 +13,10 @@ export const ideExtensionConfig = (
 		],
 		extractMessageOptions: [
 			{
-				callback: (args: { messageId: string }) => `{t("${args.messageId}")}`,
+				callback: (args: { messageId: string }) => ({
+					messageId: args.messageId,
+					messageReplacement: `{t("${args.messageId}")}`,
+				}),
 			},
 		],
 		documentSelectors: [

--- a/inlang/source-code/plugins/m-function-matcher/src/ideExtension/config.ts
+++ b/inlang/source-code/plugins/m-function-matcher/src/ideExtension/config.ts
@@ -10,20 +10,32 @@ export const ideExtensionConfig = (): ReturnType<Exclude<Plugin["addCustomApi"],
 		],
 		extractMessageOptions: [
 			{
-				callback: (args: { messageId: string }) =>
-					`{m.${args.messageId
+				callback: (args: { messageId: string }) => ({
+					messageId: args.messageId
+						.trim()
+						.replace(/[^a-zA-Z0-9\s]/g, "")
+						.replace(/\s+/g, "_")
+						.toLowerCase(),
+					messageReplacement: `{m.${args.messageId
 						.trim()
 						.replace(/[^a-zA-Z0-9\s]/g, "")
 						.replace(/\s+/g, "_")
 						.toLowerCase()}()}`,
+				}),
 			},
 			{
-				callback: (args: { messageId: string }) =>
-					`m.${args.messageId
+				callback: (args: { messageId: string }) => ({
+					messageId: args.messageId
+						.trim()
+						.replace(/[^a-zA-Z0-9\s]/g, "")
+						.replace(/\s+/g, "_")
+						.toLowerCase(),
+					messageReplacement: `m.${args.messageId
 						.trim()
 						.replace(/[^a-zA-Z0-9\s]/g, "")
 						.replace(/\s+/g, "_")
 						.toLowerCase()}()`,
+				}),
 			},
 		],
 		documentSelectors: [

--- a/inlang/source-code/plugins/t-function-matcher/src/ideExtension/config.ts
+++ b/inlang/source-code/plugins/t-function-matcher/src/ideExtension/config.ts
@@ -10,7 +10,10 @@ export const ideExtensionConfig = (): ReturnType<Exclude<Plugin["addCustomApi"],
 		],
 		extractMessageOptions: [
 			{
-				callback: (args: { messageId: string }) => `{t("${args.messageId}")}`,
+				callback: (args: { messageId: string }) => ({
+					messageId: args.messageId,
+					messageReplacement: `{t("${args.messageId}")}`,
+				}),
 			},
 		],
 		documentSelectors: [

--- a/inlang/source-code/versioned-interfaces/plugin/src/customApis/app.inlang.ideExtension.ts
+++ b/inlang/source-code/versioned-interfaces/plugin/src/customApis/app.inlang.ideExtension.ts
@@ -65,7 +65,10 @@ export const IdeExtensionConfigSchema = Type.Object({
 						selection: Type.String(),
 					}),
 				],
-				Type.String()
+				Type.Object({
+					messageId: Type.String(),
+					messageReplacement: Type.String(),
+				})
 			),
 		})
 	),


### PR DESCRIPTION
### Problem

The m function matcher should also be able to manipulate the id, and not only the replacement. This is fixing the bug of the ide extension in the function matcher who does a transformation of the id like for the message format plugin.

### Solution

Returning an object `{ messageId: string, messageReplacement: string }` instead of `string`