### PR TITLE
Paraglide js install as dev dependency

### DIFF
--- a/.changeset/fresh-penguins-exist.md
+++ b/.changeset/fresh-penguins-exist.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix `paraglide init`: Add `@inlang/paraglide-js` as devDependency instead of dependency

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
@@ -102,7 +102,7 @@ describe("addParaglideJsToDependencies()", () => {
 		const packageJson = JSON.parse(
 			(await fs.readFile("/package.json", { encoding: "utf-8" })) as string
 		)
-		expect(packageJson.dependencies["@inlang/paraglide-js"]).toBe(version)
+		expect(packageJson.devDependencies["@inlang/paraglide-js"]).toBe(version)
 	})
 })
 

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi, beforeAll, beforeEach } from "vitest"
 import {
 	addCompileStepToPackageJSON,
-	addParaglideJsToDependencies,
+	addParaglideJsToDevDependencies,
 	maybeChangeTsConfigAllowJs,
 	maybeChangeTsConfigModuleResolution,
 	checkIfPackageJsonExists,
@@ -96,7 +96,7 @@ describe("addParaglideJsToDependencies()", () => {
 		mockFiles({
 			"/package.json": "{}",
 		})
-		await addParaglideJsToDependencies()
+		await addParaglideJsToDevDependencies()
 		expect(fs.writeFile).toHaveBeenCalledOnce()
 		expect(consola.success).toHaveBeenCalledOnce()
 		const packageJson = JSON.parse(

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -250,9 +250,7 @@ Please add the following command to your build script manually:
 			}
 		)
 		if (response === false) {
-			consola.log(
-				"Please remove the paraglide-js compile command from your build script and try again."
-			)
+			consola.log("Please add the paraglide-js compile to your build script and try again.")
 			return process.exit(0)
 		} else {
 			return

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -26,7 +26,7 @@ export const initCommand = new Command()
 		await checkIfUncommittedChanges()
 		await checkIfPackageJsonExists()
 		const projectPath = await initializeInlangProject()
-		await addParaglideJsToDependencies()
+		await addParaglideJsToDevDependencies()
 		await addCompileStepToPackageJSON({ projectPath })
 		await maybeChangeTsConfigModuleResolution()
 		await maybeChangeTsConfigAllowJs()
@@ -89,16 +89,16 @@ export const maybeAddVsCodeExtension = async (args: { projectPath: string }) => 
 	}
 }
 
-export const addParaglideJsToDependencies = async () => {
+export const addParaglideJsToDevDependencies = async () => {
 	const file = await fs.readFile("./package.json", { encoding: "utf-8" })
 	const stringify = detectJsonFormatting(file)
 	const pkg = JSON.parse(file)
-	if (pkg.dependencies === undefined) {
-		pkg.dependencies = {}
+	if (pkg.devDependencies === undefined) {
+		pkg.devDependencies = {}
 	}
-	pkg.dependencies["@inlang/paraglide-js"] = version
+	pkg.devDependencies["@inlang/paraglide-js"] = version
 	await fs.writeFile("./package.json", stringify(pkg))
-	consola.success("Added @inlang/paraglide-js to the dependencies in package.json.")
+	consola.success("Added @inlang/paraglide-js to the devDependencies in package.json.")
 }
 
 export const findExistingInlangProjectPath = async (): Promise<string | undefined> => {


### PR DESCRIPTION
Closes #1666 

With this PR `paraglide init` will add `@inlang/paraglide-js` to `devDependencies` instead of the regular `dependencies`.

This has been causing some developer confusion, since a package being in the  regular `dependencies` implies that it is present at runtime. Paraglide isn't so it shouldn't be there. 