### PR TITLE
Add Telemetry to the ParaglideJS CLI

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -40,6 +40,7 @@
 	},
 	"dependencies": {
 		"@inlang/detect-json-formatting": "1.0.0",
+		"@inlang/telemetry": "*",
 		"@inlang/sdk": "*",
 		"commander": "11.1.0",
 		"consola": "3.2.3",

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -40,12 +40,14 @@
 	},
 	"dependencies": {
 		"@inlang/detect-json-formatting": "1.0.0",
-		"@inlang/telemetry": "*",
 		"@inlang/sdk": "*",
+		"@inlang/telemetry": "*",
+		"@inlang/env-variables": "*",
 		"commander": "11.1.0",
 		"consola": "3.2.3",
 		"dedent": "1.5.1",
-		"json5": "2.2.3"
+		"json5": "2.2.3",
+		"posthog-node": "3.1.3"
 	},
 	"devDependencies": {
 		"@rollup/plugin-terser": "0.4.3",
@@ -53,9 +55,9 @@
 		"@ts-morph/bootstrap": "0.20.0",
 		"@types/minimist": "1.2.3",
 		"@vitest/coverage-v8": "0.34.3",
-		"typescript": "5.2.2",
 		"memfs": "4.6.0",
 		"rollup": "3.29.1",
+		"typescript": "5.2.2",
 		"vitest": "0.34.3"
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.ts
@@ -1,11 +1,10 @@
 import { loadProject, type InlangProject } from "@inlang/sdk"
-import { parseOrigin, telemetryNode } from "@inlang/telemetry"
 import consola from "consola"
 import { compile } from "../../compiler/compile.js"
 import fs from "node:fs/promises"
 import { resolve } from "node:path"
 import { Command } from "commander"
-import { getGitRemotes } from "../../utils/git.js"
+import { telemetry } from "../../services/telemetry/implementation.js"
 
 export const compileCommand = new Command()
 	.name("compile")
@@ -21,31 +20,17 @@ export const compileCommand = new Command()
 				settingsFilePath,
 				nodeishFs: fs,
 				_capture(id, props) {
-					telemetryNode.capture({
+					telemetry.capture({
+						// @ts-ignore the event types
 						event: id,
 						properties: props,
-						distinctId: "unknown",
 					})
 				},
 			})
 		)
 
-		//For Telemetry
-		const gitOrigin = parseOrigin({
-			remotes: await getGitRemotes({ nodeishFs: fs, filepath: settingsFilePath }),
-		})
-
-		telemetryNode.capture({
-			event: "Paraglide compile",
-			groups: { repository: gitOrigin },
-			distinctId: "unknown",
-		})
-		telemetryNode.groupIdentify({
-			groupType: "repository",
-			groupKey: gitOrigin,
-			properties: {
-				name: gitOrigin,
-			},
+		telemetry.capture({
+			event: "Paraglide compile executed",
 		})
 
 		const output = compile({

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -8,6 +8,7 @@ import { detectJsonFormatting } from "@inlang/detect-json-formatting"
 import JSON5 from "json5"
 import childProcess from "node:child_process"
 import { version } from "../state.js"
+import { telemetry } from "../../services/telemetry/implementation.js"
 
 consola.options = {
 	...consola.options,
@@ -22,6 +23,7 @@ export const initCommand = new Command()
 	.summary("Initializes inlang Paraglide-JS.")
 	.action(async () => {
 		consola.box("Welcome to inlang Paraglide-JS 🪂")
+		telemetry.capture({ event: "Paraglide init executed" })
 
 		await checkIfUncommittedChanges()
 		await checkIfPackageJsonExists()

--- a/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/events.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/events.ts
@@ -3,4 +3,4 @@
  *
  * Exists to avoid typos/always set the correct event name and properties.
  */
-export type TelemetryEvents = "Paraglide compile executed" | "CLI started"
+export type TelemetryEvents = "Paraglide compile executed" | "Paraglide init executed"

--- a/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/events.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/events.ts
@@ -1,0 +1,6 @@
+/**
+ * Typesafe telemetry events.
+ *
+ * Exists to avoid typos/always set the correct event name and properties.
+ */
+export type TelemetryEvents = "Paraglide compile executed" | "CLI started"

--- a/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/implementation.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/implementation.ts
@@ -1,0 +1,60 @@
+import { publicEnv } from "@inlang/env-variables"
+import { PostHog } from "posthog-node"
+import type { TelemetryEvents } from "./events.js"
+import { getGitRemotes } from "../../utils/git.js"
+import { parseOrigin } from "@inlang/telemetry"
+
+export const gitOrigin = parseOrigin({ remotes: await getGitRemotes() })
+
+const posthog = new PostHog(publicEnv.PUBLIC_POSTHOG_TOKEN ?? "placeholder", {
+	host: "https://eu.posthog.com",
+	// Events are not captured if not immediately flushed.
+	//
+	// Posthog shouldn't batch events because CLI commands
+	// are short-lived, see https://posthog.com/docs/libraries/node.
+	flushAt: 1,
+	flushInterval: 0,
+})
+
+/**
+ * Telmetry for the CLI.
+ *
+ * Auto injects the git origin url.
+ */
+export const telemetry = new Proxy(posthog, {
+	get(target, prop) {
+		// If the env variable is set, use the PostHog SDK. Otherwise, use a proxy that
+		// returns a no-op function.
+		if (publicEnv.PUBLIC_POSTHOG_TOKEN === undefined) {
+			return () => undefined
+		}
+		// Auto inject the git origin url and user id.
+		else if (prop === "capture") {
+			return capture
+		}
+		return (target as any)[prop]
+	},
+}) as unknown as Omit<PostHog, "capture"> & { capture: typeof capture }
+
+/**
+ * Wrapper to auto inject the git origin url and user id.
+ */
+function capture(args: CaptureEventArguments) {
+	return posthog.capture({
+		...args,
+		distinctId: "unknown",
+		groups: {
+			repository: gitOrigin,
+		},
+	})
+}
+
+/**
+ * Typesafe wrapper around the `telemetryNode.capture` method.
+ *
+ * Exists to avoid typos/always set the correct event name and properties.
+ */
+type CaptureEventArguments =
+	| Omit<Parameters<PostHog["capture"]>[0], "distinctId" | "groups"> & {
+			event: TelemetryEvents
+	  }

--- a/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/telemetry/index.ts
@@ -1,0 +1,2 @@
+export { telemetry } from "./implementation.js"
+export { gitOrigin } from "./implementation.js"

--- a/inlang/source-code/paraglide/paraglide-js/src/utils/git.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/utils/git.ts
@@ -1,0 +1,28 @@
+import { findRoot, listRemotes } from "isomorphic-git"
+import type { NodeishFilesystem } from "@lix-js/fs"
+import fs from "node:fs"
+
+// TODO: move to lix api when local repos supported
+/**
+ * Gets the git origin url of the current repository.
+ *
+ * @params args.filepath filepath override for injecting non cwd path for testing
+ * @params args.nodeishFs fs implementation override for injecting virtual fs for testing
+ * @returns The git origin url or undefined if it could not be found.
+ */
+export async function getGitRemotes(
+	args: { filepath?: string; nodeishFs?: NodeishFilesystem } = {}
+) {
+	try {
+		const usedFs = args.nodeishFs || fs
+		const root = await findRoot({ fs: usedFs, filepath: args.filepath || process.cwd() })
+
+		const remotes = await listRemotes({
+			fs: usedFs,
+			dir: root,
+		})
+		return remotes
+	} catch (e) {
+		return undefined
+	}
+}

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
 		"nx-cloud": "16.4.0",
 		"prettier": "2.8.3",
 		"typescript": "5.2.2"
+	},
+	"dependencies": {
+		"isomorphic-git": "1.25.0"
 	}
 }


### PR DESCRIPTION
This PR adds telemetry to the paraglide CLI. The runtime remains unaffected. 
It tracks executions of `paraglide-js init` and `paragrlide-js compile`.

Thanks to @jannesblobel for helping me get this working! 