### PR TITLE
[CI Fix] Remove dry run from npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"clean": "pnpm recursive run clean --if-present && rm -rf ./.env ./node_modules",
 		"----- CI ---- used to test the codebase on every commit": "",
 		"ci": "pnpm i && pnpm format && pnpm lint && pnpm build && pnpm test",
-		"ci:publish": "pnpm --filter !vs-code-extension publish -r --dry-run",
+		"ci:publish": "pnpm --filter !vs-code-extension publish -r",
 		"ci:version": "npx changeset version"
 	},
 	"engines": {


### PR DESCRIPTION
I hopefully marked all private packages as private, so the npm publish action should be good now.