### PR TITLE
[Fix Publishing] Mark template packages private

### DIFF
--- a/inlang/source-code/create-project/package.json
+++ b/inlang/source-code/create-project/package.json
@@ -2,9 +2,7 @@
 	"name": "@inlang/create-project",
 	"type": "module",
 	"version": "1.1.0",
-	"publishConfig": {
-		"access": "public"
-	},
+	"private": true,
 	"exports": {
 		".": "./dist/index.js"
 	},

--- a/inlang/source-code/templates/message-lint-rule/package.json
+++ b/inlang/source-code/templates/message-lint-rule/package.json
@@ -2,6 +2,7 @@
 	"name": "template-message-lint-rule",
 	"version": "0.1.0",
 	"type": "module",
+	"private": "true",
 	"files": [
 		"./dist"
 	],

--- a/inlang/source-code/templates/plugin/package.json
+++ b/inlang/source-code/templates/plugin/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "template-plugin",
+	"private": true,
 	"version": "0.1.0",
 	"type": "module",
 	"files": [


### PR DESCRIPTION
We accidentally published our template packages to `npm`, because they were not marked as private. 
This PR explicitly marks the templates as `private`, so that won't happen again