### PR TITLE
[Paraglide] Fix Eslint not ignoring the output

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -22,11 +22,14 @@ test("the files should include a prettierignore file", async () => {
 	expect(output).toHaveProperty(".prettierignore")
 	expect(output[".prettierignore"]).toContain("*")
 })
-// ignore eslint stuff
-test("files should include an eslint ignore", async () => {
-	expect(output).toHaveProperty(".eslintignore")
-	expect(output[".eslintignore"]).toContain("*")
-})
+
+// All JS files must be eslint ignored
+test("the files should include an eslint ignore comment", async () => {
+	for (const [filePath, content] of Object.entries(output)) {
+		if (!filePath.endsWith(".js")) continue;
+		expect(content).toContain("/* eslint-disable */")
+	}
+});
 
 test("imports in the messages.js index file should use underscores instead of hyphens to avoid invalid JS imports", async () => {
 	expect(output["messages.js"]).toContain("import * as en_US")

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
@@ -48,7 +48,6 @@ export const compile = (args: {
 		// boilerplate files
 		".prettierignore": ignoreDirectory,
 		".gitignore": ignoreDirectory,
-		".eslintignore": ignoreDirectory,
 		// resources
 		// (messages/en.js)
 		// (messages/de.js)
@@ -57,6 +56,7 @@ export const compile = (args: {
 			Object.entries(resources).map(([languageTag, content]) => [
 				`messages/${languageTag}.js`,
 				`
+/* eslint-disable */
 /** 
 * This file contains language specific message functions for tree-shaking. 
 * 
@@ -70,6 +70,7 @@ export const compile = (args: {
 		),
 		// message index file
 		"messages.js": `
+/* eslint-disable */
 import { languageTag } from "./runtime.js"
 ${Object.keys(resources)
 	.map(
@@ -81,6 +82,7 @@ ${Object.keys(resources)
 ${compiledMessages.map((message) => message.index).join("\n\n")}
 `,
 		"runtime.js": `
+/* eslint-disable */
 /** @type {((tag: AvailableLanguageTag) => void) | undefined} */ 
 let _onSetLanguageTag
 


### PR DESCRIPTION
Closes #1712 

This PR changes how we tell eslint to ignore the paraglide output directory.
- Removes the `.eslintignore` since it doesn't work outside the current working directory (usually root) ([Source](https://eslint.org/docs/latest/use/configure/ignore#the-eslintignore-file))
- Adds `/* eslint-disable */` comments to each JS file in the output