### PR TITLE
[Breaking] Make `--project` a required argument for `paraglide-js compile`

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"scripts": {
 		"_dev": "vite dev",
-		"build": "paraglide-js compile && vite build",
-		"test": "paraglide-js compile && vite build",
+		"build": "paraglide-js compile --project ./project.inlang.json && vite build",
+		"test": "paraglide-js compile --project ./project.inlang.json && vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"

--- a/inlang/source-code/paraglide/paraglide-js/example/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"private": true,
 	"scripts": {
-		"build": "paraglide-js compile && tsc",
+		"build": "paraglide-js compile --project ./project.inlang.json && tsc",
 		"pretest": "paraglide-js compile",
 		"test": "vitest run"
 	},

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.test.ts
@@ -22,9 +22,10 @@ beforeEach(() => {
 	vi.spyOn(consola, "log").mockImplementation(() => undefined as never)
 	vi.spyOn(consola, "info").mockImplementation(() => undefined as never)
 	vi.spyOn(consola, "success").mockImplementation(() => undefined as never)
-	vi.spyOn(consola, "error").mockImplementation(() => undefined as never)
+	vi.spyOn(consola, "error").mockImplementation(console.error)
 	vi.spyOn(consola, "warn").mockImplementation(() => undefined as never)
-	vi.spyOn(process, "exit").mockImplementation(() => {
+	vi.spyOn(process, "exit").mockImplementation((e) => {
+		console.error(`PROCESS.EXIT()`, e)
 		throw "PROCESS.EXIT()"
 	})
 })
@@ -69,7 +70,9 @@ test("it should compile into the default outdir", async () => {
 			],
 		}),
 	})
-	await compileCommand.parseAsync(["--project", "./project.inlang.json"])
+
+	// I have no idea why, but the { from: "user" } is required for the test to pass
+	await compileCommand.parseAsync(["--project", "./project.inlang.json"], { from: "user" })
 	expect(_fs.existsSync("./src/paraglide/messages.js")).toBe(true)
 })
 
@@ -101,7 +104,10 @@ test("it should compile a project into the provided outdir", async () => {
 				],
 			}),
 		})
-		await compileCommand.parseAsync(["--project", "./project.inlang.json", "--outdir", outdir])
+		// I have no idea why, but the { from: "user" } is required for the test to pass
+		await compileCommand.parseAsync(["--project", "./project.inlang.json", "--outdir", outdir], {
+			from: "user",
+		})
 		expect(_fs.existsSync(`${outdir}/messages.js`)).toBe(true)
 	}
 })

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.ts
@@ -8,7 +8,7 @@ import { Command } from "commander"
 export const compileCommand = new Command()
 	.name("compile")
 	.summary("Compiles inlang Paraglide-JS.")
-	.requiredOption("--project <path>", "The path to the inlang project.", "./project.inlang.json")
+	.requiredOption("--project <path>", "The path to the inlang project.")
 	.requiredOption("--outdir <path>", "The path to the output directory.", "./src/paraglide")
 	.action(async (options: { project: string; outdir: string }) => {
 		consola.info(`Compiling inlang project at "${options.project}".`)
@@ -18,7 +18,6 @@ export const compileCommand = new Command()
 		const project = exitIfErrors(
 			await loadProject({
 				settingsFilePath: path,
-				//@ts-ignore
 				nodeishFs: fs,
 			})
 		)

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/optionsType.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/optionsType.ts
@@ -1,6 +1,6 @@
 export const optionsType = (args: { languageTags: Iterable<string> }) => {
 	return `@param {{ languageTag?: ${
-		Array.from(args.languageTags).map(quote).join(" | ") ?? "undefined"
+		[...args.languageTags].map(quote).join(" | ") ?? "undefined"
 	} }} options`
 }
 


### PR DESCRIPTION
Closes #1508 

It wasn't obvious that you could provide the location of the project file to `paraglide-js compile`, so it was decided to make it a required argument.

This PR:
- Makes `--project` a required argument for `paraglide-js compile`
- Updates all our build commands to include the `--project` flag