### PR TITLE
rename id's of syntax matcher

### DIFF
--- a/.changeset/real-boxes-look.md
+++ b/.changeset/real-boxes-look.md
@@ -1,0 +1,6 @@
+---
+"@inlang/plugin-m-function-matcher": minor
+"@inlang/plugin-t-function-matcher": minor
+---
+
+rename id's of syntax matcher

--- a/inlang/source-code/plugins/m-function-matcher/src/plugin.ts
+++ b/inlang/source-code/plugins/m-function-matcher/src/plugin.ts
@@ -3,7 +3,7 @@ import { displayName, description } from "../marketplace-manifest.json"
 import { PluginSettings } from "./settings.js"
 import { ideExtensionConfig } from "./ideExtension/config.js"
 
-const id = "plugin.inlang.paraglideJs"
+const id = "plugin.inlang.mFunctionMatcher"
 
 export const plugin: Plugin<{
 	[id]: PluginSettings

--- a/inlang/source-code/plugins/t-function-matcher/src/plugin.ts
+++ b/inlang/source-code/plugins/t-function-matcher/src/plugin.ts
@@ -3,7 +3,7 @@ import { displayName, description } from "../marketplace-manifest.json"
 import { PluginSettings } from "./settings.js"
 import { ideExtensionConfig } from "./ideExtension/config.js"
 
-const id = "plugin.inlang.t-function-matcher"
+const id = "plugin.inlang.tFunctionMatcher"
 
 export const plugin: Plugin<{
 	[id]: PluginSettings


### PR DESCRIPTION
this PR solves the mystery "Expected union value" error. This error has to be improved sometime in the future. Probably there is also coming something from upstream: https://github.com/sinclairzx81/typebox/issues/640