### PR TITLE
`paraglide-js init` detect tech-stack and suggest adapter

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -8,6 +8,7 @@ import { detectJsonFormatting } from "@inlang/detect-json-formatting"
 import JSON5 from "json5"
 import childProcess from "node:child_process"
 import { version } from "../state.js"
+import { detectTechStack } from "../../services/detect-techstack/detect.js"
 
 consola.options = {
 	...consola.options,
@@ -31,6 +32,7 @@ export const initCommand = new Command()
 		await maybeChangeTsConfigModuleResolution()
 		await maybeChangeTsConfigAllowJs()
 		await maybeAddVsCodeExtension({ projectPath })
+		await maybeSuggestAdapter()
 
 		consola.box(
 			"inlang Paraglide-JS has been set up sucessfully.\n\n1. Run your install command (npm i, yarn install, etc)\n2. Run the build script (npm run build, or similar.)\n3. Done :) Happy paragliding 🪂\n\n For questions and feedback, visit https://github.com/inlang/monorepo/discussions.\n"
@@ -382,6 +384,44 @@ export const maybeChangeTsConfigAllowJs = async () => {
 			consola.error(
 				"The compiler options have not been adjusted. Please set the `compilerOptions.allowJs` to `true`."
 			)
+		}
+	}
+}
+
+/**
+ * Try to detect the tech stack and suggest an appropriate adapter.
+ */
+export async function maybeSuggestAdapter() {
+	const techStack = await detectTechStack()
+	switch (techStack) {
+		case "vite": {
+			consola.info(
+				`It looks like you're using vite. \nYou should take a look at @inlang/paraglide-js-adapter-vite to take your paraglide experience to the next level.`
+			)
+			break
+		}
+
+		case "rollup": {
+			consola.info(
+				`It looks like you're using rollup. \nYou should take a look at @inlang/paraglide-js-adapter-rollup to take your paraglide experience to the next level.`
+			)
+			break
+		}
+
+		case "webpack": {
+			consola.info(
+				`It looks like you're using webpack. \nYou should take a look at @inlang/paraglide-js-adapter-webpack to take your paraglide experience to the next level.`
+			)
+			break
+		}
+
+		case "next":
+		case "sveltekit":
+		case "solid-start":
+		case "other":
+		default: {
+			// No adapter to suggest
+			return
 		}
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/services/detect-techstack/detect.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/detect-techstack/detect.test.ts
@@ -1,0 +1,144 @@
+import { createNodeishMemoryFs } from "@inlang/sdk/test-utilities"
+import { detectTechStack } from "./detect.js"
+import memfs from "memfs"
+import fsSync from "fs"
+import fs from "node:fs/promises"
+import { describe, expect, test, vi } from "vitest"
+
+describe("detectTechStack", () => {
+	test("it should detect SvelteKit", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+				"devDependencies": {
+					"@sveltejs/adapter-auto": "^2.0.0",
+					"@sveltejs/kit": "^1.5.0",
+					"svelte": "^3.54.0",
+					"svelte-check": "^3.0.1",
+					"tslib": "^2.4.1",
+					"typescript": "^5.0.0",
+					"vite": "^4.2.0"
+				}
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("sveltekit")
+	})
+
+	test("it should detect SolidStart", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+				"devDependencies": {
+					"@types/node": "^18.17.5",
+					"esbuild": "^0.14.54",
+					"postcss": "^8.4.28",
+					"solid-start-node": "^0.3.10",
+					"typescript": "^4.9.5",
+					"vite": "^4.4.9"
+				},
+				"dependencies": {
+					"@solidjs/meta": "^0.29.1",
+					"@solidjs/router": "^0.8.3",
+					"solid-js": "^1.8.5",
+					"solid-start": "^0.3.10"
+				}
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("solid-start")
+	})
+
+	test("it should detect Next.js", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+                "dependencies": {
+                    "react": "^18",
+                    "react-dom": "^18",
+                    "next": "14.0.3"
+                },
+                  "devDependencies": {
+                    "typescript": "^5",
+                    "@types/node": "^20",
+                    "@types/react": "^18",
+                    "@types/react-dom": "^18"
+                }
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("next")
+	})
+
+	test("it should standalone vite", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+                "devDependencies": {
+                    "vite": "^4.2.0"
+                }
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("vite")
+	})
+
+	test("it should standalone rollup", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+                "devDependencies": {
+                    "rollup": "^4.2.0"
+                }
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("rollup")
+	})
+
+	test("it should standalone webpack", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+                "devDependencies": {
+                    "webpack": "^5.0.0"
+                }
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("webpack")
+	})
+
+	test("it should admit when it has no idea what this is", async () => {
+		mockFiles({
+			//Leave extra dependencies in to make sure they don't cause false negatives
+			"package.json": `{
+                "devDependencies": {
+                    "jeremy": "^4.2.0"
+                }
+			}`,
+		})
+
+		expect(await detectTechStack()).toBe("other")
+	})
+})
+
+const mockFiles = (files: memfs.NestedDirectoryJSON) => {
+	const _memfs = memfs.createFsFromVolume(memfs.Volume.fromNestedJSON(files))
+	const lixFs = createNodeishMemoryFs()
+	vi.spyOn(fsSync, "existsSync").mockImplementation(_memfs.existsSync)
+	for (const prop in fs) {
+		// @ts-ignore - memfs has the same interface as node:fs/promises
+		if (typeof fs[prop] !== "function") continue
+
+		// @ts-ignore - memfs dies not have a watch interface - quick fix should be updated
+		if (fs[prop].name === "watch") {
+			// @ts-ignore - memfs has the same interface as node:fs/promises
+			vi.spyOn(fs, prop).mockImplementation(lixFs[prop])
+		} else {
+			// @ts-ignore - memfs has the same interface as node:fs/promises
+			vi.spyOn(fs, prop).mockImplementation(_memfs.promises[prop])
+		}
+	}
+	return { existsSync: _memfs.existsSync }
+}

--- a/inlang/source-code/paraglide/paraglide-js/src/services/detect-techstack/detect.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/detect-techstack/detect.ts
@@ -1,0 +1,35 @@
+import type { TechStack } from "./environments.js"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+/**
+ * Attempts to detect which tech-stack we're running in
+ * so that we can tailor the installation instructions to the user.
+ */
+export async function detectTechStack(): Promise<TechStack> {
+	const packageJson = await getPackageJson()
+	if (!packageJson) return "other"
+
+	const dependencies = Object.keys(packageJson?.dependencies ?? {})
+	const devDependencies = Object.keys(packageJson?.devDependencies ?? {})
+
+	//Check in order of most specific to least specific
+	if (dependencies.includes("next")) return "next"
+	if (dependencies.includes("solid-start")) return "solid-start"
+	if (devDependencies.includes("@sveltejs/kit")) return "sveltekit"
+	if (devDependencies.includes("webpack")) return "webpack"
+	if (devDependencies.includes("rollup")) return "rollup"
+	if (devDependencies.includes("vite")) return "vite"
+	return "other"
+}
+
+async function getPackageJson(): Promise<Record<string, any> | null> {
+	const packageJson = path.join(process.cwd(), "package.json")
+
+	try {
+		const contents = await fs.readFile(packageJson, "utf-8")
+		return JSON.parse(contents)
+	} catch {
+		return null
+	}
+}

--- a/inlang/source-code/paraglide/paraglide-js/src/services/detect-techstack/environments.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/detect-techstack/environments.ts
@@ -1,0 +1,8 @@
+export type TechStack =
+	| "vite"
+	| "rollup"
+	| "webpack"
+	| "sveltekit"
+	| "next"
+	| "solid-start"
+	| "other"


### PR DESCRIPTION
As described in #1570 

**Don't merge until #1669 is merged**

This PR extends the `paraglide-js init` command.
After completing it's usually init process, it will try and detect which tech-stack is being used by reading `package.json` and suggest and adapter. 

