### PR TITLE
[Paraglide Plugins] Fix package.json

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-rollup/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-rollup/package.json
@@ -36,14 +36,11 @@
         "test": "vitest run --passWithNoTests"
     },
     "dependencies": {
-        "@inlang/paraglide-js-adapter-unplugin": "*"
+        "@inlang/paraglide-js-adapter-unplugin": "workspace:*"
     },
     "devDependencies": {
         "@types/node": "20.9.3",
         "typescript": "5.2.2",
         "vitest": "0.34.3"
-    },
-    "peerDependencies": {
-        "rollup": "*"
     }
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-rollup/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-rollup/src/index.ts
@@ -1,5 +1,4 @@
 import { paraglide as unpluginParaglide } from "@inlang/paraglide-js-adapter-unplugin"
-import type { Plugin } from "rollup"
 
 type PluginOptions = Parameters<typeof unpluginParaglide.rollup>
-export const paraglide: (...args: PluginOptions) => Plugin | Plugin[] = unpluginParaglide.rollup
+export const paraglide: (...args: PluginOptions) => any = unpluginParaglide.rollup

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/package.json
@@ -20,7 +20,7 @@
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
 		"vite": "^4.4.2",
-		"@inlang/paraglide-js-adapter-vite": "*"
+		"@inlang/paraglide-js-adapter-vite": "workspace:*"
 	},
 	"type": "module"
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/package.json
@@ -42,8 +42,8 @@
         "test": "vitest run --passWithNoTests"
     },
     "dependencies": {
-        "@inlang/paraglide-js": "*",
-        "@inlang/sdk": "*",
+        "@inlang/paraglide-js": "workspace:*",
+        "@inlang/sdk": "workspace:*",
         "unplugin": "1.5.1"
     },
     "devDependencies": {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-vite/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-vite/package.json
@@ -39,7 +39,7 @@
         "test": "pnpm -r --filter=@inlang/paraglide-js-adapter-vite-test-basic run _build"
     },
     "dependencies": {
-        "@inlang/paraglide-js-adapter-unplugin": "*"
+        "@inlang/paraglide-js-adapter-unplugin": "workspace:*"
     },
     "devDependencies": {
         "@types/node": "20.9.3",

--- a/inlang/source-code/paraglide/paraglide-js-adapter-webpack/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-webpack/package.json
@@ -38,7 +38,7 @@
         "test": "vitest run --passWithNoTests"
     },
     "dependencies": {
-        "@inlang/paraglide-js-adapter-unplugin": "*"
+        "@inlang/paraglide-js-adapter-unplugin": "workspace:*"
     },
     "devDependencies": {
         "@types/node": "20.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -988,11 +988,8 @@ importers:
   inlang/source-code/paraglide/paraglide-js-adapter-rollup:
     dependencies:
       '@inlang/paraglide-js-adapter-unplugin':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../paraglide-js-adapter-unplugin
-      rollup:
-        specifier: '*'
-        version: 3.29.1
     devDependencies:
       '@types/node':
         specifier: 20.9.3
@@ -1025,7 +1022,7 @@ importers:
         specifier: workspace:*
         version: link:../../paraglide-js
       '@inlang/paraglide-js-adapter-vite':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../../paraglide-js-adapter-vite
       '@inlang/plugin-message-format':
         specifier: workspace:*
@@ -1055,10 +1052,10 @@ importers:
   inlang/source-code/paraglide/paraglide-js-adapter-unplugin:
     dependencies:
       '@inlang/paraglide-js':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../paraglide-js
       '@inlang/sdk':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../../sdk
       unplugin:
         specifier: 1.5.1
@@ -1077,7 +1074,7 @@ importers:
   inlang/source-code/paraglide/paraglide-js-adapter-vite:
     dependencies:
       '@inlang/paraglide-js-adapter-unplugin':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../paraglide-js-adapter-unplugin
     devDependencies:
       '@types/node':
@@ -1108,7 +1105,7 @@ importers:
   inlang/source-code/paraglide/paraglide-js-adapter-webpack:
     dependencies:
       '@inlang/paraglide-js-adapter-unplugin':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../paraglide-js-adapter-unplugin
     devDependencies:
       '@types/node':


### PR DESCRIPTION
#1669 was just merged adding bundler plugins for paraglide JS. 

However, since the pnpm migration happened in the meantime, the bundler plugins were still using the old `"*"` syntax and not the `"workspace:*"` syntax in their `package.json`. This PR fixes that.