### PR TITLE
[CI] Re-enable Nx cloud

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,22 +1,85 @@
 {
-	"tasksRunnerOptions": {
-		"default": {
-			"runner": "nx/tasks-runners/default",
-			"options": {
-				"cacheableOperations": ["build", "test", "lint", "format"],
-				"accessToken": "ODlkYjAwMjYtMGMyMS00YTI3LWIzNTAtN2RhZjgwYzAwZGJifHJlYWQtd3JpdGU="
-			}
-		}
-	},
+	"$schema": "./node_modules/nx/schemas/nx-schema.json",
 	"targetDefaults": {
 		"build": {
-			"dependsOn": ["^build"]
+			"dependsOn": [
+				"^build"
+			],
+			"inputs": [
+				"default",
+				"^default",
+				{
+					"env": "ALGOLIA_ADMIN"
+				},
+				{
+					"env": "ALGOLIA_APPLICATION"
+				},
+				{
+					"env": "JWE_SECRET"
+				},
+				{
+					"env": "NODE_VERSION"
+				},
+				{
+					"env": "PUBLIC_GIT_PROXY_BASE_URL"
+				},
+				{
+					"env": "PUBLIC_LIX_GITHUB_APP_CLIENT_ID"
+				},
+				{
+					"env": "LIX_GITHUB_APP_CLIENT_SECRET"
+				},
+				{
+					"env": "PUBLIC_LIX_GITHUB_APP_NAME"
+				},
+				{
+					"env": "PUBLIC_SERVER_BASE_URL"
+				},
+				{
+					"env": "SESSION_COOKIE_SECRET"
+				},
+				{
+					"env": "SERVER_SENTRY_DSN"
+				},
+				{
+					"env": "PUBLIC_WEBSITE_SENTRY_DSN"
+				},
+				{
+					"env": "PUBLIC_POSTHOG_TOKEN"
+				},
+				{
+					"env": "OPEN_AI_KEY"
+				},
+				{
+					"env": "GOOGLE_TRANSLATE_API_KEY"
+				}
+			],
+			"cache": true
 		},
 		"dev": {
-			"dependsOn": ["^build"]
+			"dependsOn": [
+				"^build"
+			]
 		},
 		"test": {
-			"dependsOn": ["^build"]
+			"dependsOn": [
+				"^build"
+			],
+			"cache": true
+		},
+		"lint": {
+			"dependsOn": [
+				"format"
+			],
+			"cache": true
+		},
+		"format": {
+			"cache": true
 		}
+	},
+	"nxCloudAccessToken": "NmIwOWM4ZjUtZWNkMi00NTY1LThmZmEtNzMzZDEzOTZkYmVifHJlYWQ=",
+	"affected": {
+		"defaultBase": "origin/main"
 	}
 }
+

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"eslint-config-prettier": "^8.6.0",
 		"eslint-plugin-unicorn": "^45.0.2",
 		"nx": "17.1.3",
-		"nx-cloud": "16.4.0",
+		"nx-cloud": "16.5.2",
 		"prettier": "2.8.3",
 		"typescript": "5.2.2"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 17.1.3
         version: 17.1.3
       nx-cloud:
-        specifier: 16.4.0
-        version: 16.4.0
+        specifier: 16.5.2
+        version: 16.5.2
       prettier:
         specifier: 2.8.3
         version: 2.8.3
@@ -3703,10 +3703,10 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@nrwl/nx-cloud@16.4.0:
-    resolution: {integrity: sha512-QitrYK6z9ceagetBlgLMZnC0T85k2JTk+oK0MxZ5p/woclqeYN7SiGNZgMzDq8TjJwt8Fm/MDnsSo3xtufmLBg==}
+  /@nrwl/nx-cloud@16.5.2:
+    resolution: {integrity: sha512-oHO5T1HRJsR9mbRd8eUqMBPCgqVZLSbAh3zJoPFmhEmjbM4YB9ePRpgYFT8dRNeZUOUd/8Yt7Pb6EVWOHvpD/w==}
     dependencies:
-      nx-cloud: 16.4.0
+      nx-cloud: 16.5.2
     transitivePeerDependencies:
       - debug
     dev: true
@@ -11375,11 +11375,11 @@ packages:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
     dev: true
 
-  /nx-cloud@16.4.0:
-    resolution: {integrity: sha512-jbq4hWvDwRlJVpxgMgbmNSkue+6XZSn53R6Vo6qmCAWODJ9KY1BZdZ/9VRL8IX/BRKebVFiXp3SapFB1qPhH8A==}
+  /nx-cloud@16.5.2:
+    resolution: {integrity: sha512-1t1Ii9gojl8r/8hFGaZ/ZyYR0Cb0hzvXLCsaFuvg+EJEFdvua3P4cfNya/0bdRrm+7Eb/ITUOskbvYq4TSlyGg==}
     hasBin: true
     dependencies:
-      '@nrwl/nx-cloud': 16.4.0
+      '@nrwl/nx-cloud': 16.5.2
       axios: 1.1.3
       chalk: 4.1.2
       dotenv: 10.0.0
@@ -15622,7 +15622,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
     dev: true
 
   /yargs@17.7.2:


### PR DESCRIPTION
#1705 

This PR re-enables Nx cloud caching. 
We avoid issues with changing Env variables by including them when NX calculates the hash for the cache, so changes in our Env variables will cause the cache to be invalidated. 

The token included in `nx.json` is read-only, meaning that it can't update the cache. A read-write token is made injected to our developers & CI pipeline via doppler. This keeps random people from messing with our cache. 

(It took me way too long to figure out that I needed to update `nx-cloud`. The error message is very well hidden)