### PR TITLE
add `sourceLanguageTag` & `targetLanguageTags` options to `machine translate` command

### DIFF
--- a/.changeset/moody-laws-live.md
+++ b/.changeset/moody-laws-live.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": minor
+---
+
+add `sourceLanguageTag` & `targetLanguageTags` options to `machine translate` command

--- a/inlang/source-code/cli/README.md
+++ b/inlang/source-code/cli/README.md
@@ -79,7 +79,7 @@ To use the inlang CLI, you need a `project.inlang.json` file configured, see [he
 | **CLI Version** | `npx @inlang/cli@latest [command]`                   | Get the latest version of the inlang CLI.                                                                     |
 | **Project**     | `npx @inlang/cli project validate [options]`                  | Manage your inlang project, including validation and interactive project creation.                           |
 | **Lint**        | `npx @inlang/cli lint [options]`                     | Lint translations using configured rules. Options include `--no-fail`, `--project`, and `--languageTags`.      |
-| **Machine**     | `npx @inlang/cli machine translate [options]`        | Automate translation processes. Options include `-f, --force` and `--project <path>`.                          |
+| **Machine**     | `npx @inlang/cli machine translate [options]`        | Automate translation processes. Options include `-f, --force`, `--project <path>`, `--sourceLanguageTag <source>` and `--targetLanguageTags <targets...>`                          |
 | **Open**        | `npx @inlang/cli open editor`                     | Open parts of the Inlang infrastructure in your default browser, including the editor.                        |
 | **Module**      | `npx @inlang/cli module [command]`                   | Interact with Inlang modules, including initialization and building. Commands:  `init [options]`   Initialize a new inlang module codebase,   `build [options]`  build an inlang module. Options include `--type`, `--entry`, and `--outdir`. |
 

--- a/inlang/source-code/cli/README.md
+++ b/inlang/source-code/cli/README.md
@@ -73,7 +73,6 @@ To use the inlang CLI, you need a `project.inlang.json` file configured, see [he
 
 # Commands
 
-
 | Name            | Command                                               | Description                                                                                                  |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | **CLI Version** | `npx @inlang/cli@latest [command]`                   | Get the latest version of the inlang CLI.                                                                     |
@@ -83,9 +82,9 @@ To use the inlang CLI, you need a `project.inlang.json` file configured, see [he
 | **Open**        | `npx @inlang/cli open editor`                     | Open parts of the Inlang infrastructure in your default browser, including the editor.                        |
 | **Module**      | `npx @inlang/cli module [command]`                   | Interact with Inlang modules, including initialization and building. Commands:  `init [options]`   Initialize a new inlang module codebase,   `build [options]`  build an inlang module. Options include `--type`, `--entry`, and `--outdir`. |
 
-<!-- 
+---
 
-
+# Usage
 
 We recommend using the CLI with `npx` to avoid installing the CLI globally. Not installing the CLI globally has the following advantages:
 
@@ -133,8 +132,9 @@ npx @inlang/cli machine translate
 The translate command has the following options:
 
 - `-f, --force`: If this option is set, the command will not prompt confirmation. This is useful for CI/CD build pipelines. **We advise you to only use `machine translate` in build pipelines to avoid out-of-context/wrong translations.**
-
 - `--project <path>`: Specifies the path to the project root. The default project root is the current working directory.
+- `--sourceLanguageTag <source>`: Specifies the source language tag. The default source language tag is the one specified in the `project.inlang.json` file.
+- `--targetLanguageTags <targets...>`: Specifies the target language tags as comma seperated list (e.g. sk,zh,pt-BR). The default target language tags are the ones specified in the `project.inlang.json` file.
 
 This command reads the project.inlang.json file in the repository and retrieves the resources and reference language specified in the configuration. It then translates all messages from the reference language to other languages defined in the configuration.
 
@@ -158,7 +158,7 @@ npx @inlang/cli project validate
 
 **Options**
 
-The translate command has the following options:
+The validate command has the following options:
 
 - `--project <path>`: Specifies the path to the project root. The default project root is the current working directory.
 

--- a/inlang/source-code/cli/src/commands/machine/translate.ts
+++ b/inlang/source-code/cli/src/commands/machine/translate.ts
@@ -3,7 +3,7 @@ import { Command } from "commander"
 import { rpc } from "@inlang/rpc"
 import { getInlangProject } from "../../utilities/getInlangProject.js"
 import { log } from "../../utilities/log.js"
-import type { InlangProject } from "@inlang/sdk"
+import { type InlangProject, ProjectSettings } from "@inlang/sdk"
 import prompts from "prompts"
 import { projectOption } from "../../utilities/globalFlags.js"
 
@@ -11,6 +11,11 @@ export const translate = new Command()
 	.command("translate")
 	.requiredOption(projectOption.flags, projectOption.description, projectOption.defaultValue)
 	.option("-f, --force", "Force machine translation and skip the confirmation prompt.", false)
+	.option("--sourceLanguageTag <source>", "Source language tag for translation.")
+	.option(
+		"--targetLanguageTags <targets...>",
+		"Comma separated list of target language tags for translation."
+	)
 	.description("Machine translate all resources.")
 	.action(async (args: { force: boolean; project: string }) => {
 		try {
@@ -40,29 +45,58 @@ export const translate = new Command()
 
 export async function translateCommandAction(args: { project: InlangProject }) {
 	try {
+		const options = translate.opts()
 		const projectConfig = args.project.settings()
 
 		if (!projectConfig) {
-			log.error(`No inlang config found, please add a project.inlang.json file`)
+			log.error(`No inlang settings file found, please add a project.inlang.json file`)
 			return
 		}
 
-		const sourceLanguageTag = projectConfig.sourceLanguageTag
-		// Get languages to translate to with the reference language removed
+		const allLanguageTags = [...projectConfig.languageTags, projectConfig.sourceLanguageTag]
 
-		const languagesTagsToTranslateTo = projectConfig.languageTags.filter(
-			// @ts-ignore - type mismtach - fix after refactor
-			(tag) => tag !== sourceLanguageTag
-		)
+		const sourceLanguageTag: ProjectSettings["sourceLanguageTag"] =
+			options.sourceLanguageTag || projectConfig.sourceLanguageTag
+		if (!sourceLanguageTag) {
+			log.error(
+				`No source language tag defined. Please define a source language tag in the project.inlang.json file or as an argument with --sourceLanguageTag.`
+			)
+			return
+		}
+		if (options.sourceLanguageTag && !allLanguageTags.includes(options.sourceLanguageTag)) {
+			log.error(
+				`The source language tag "${options.sourceLanguageTag}" is not included in the project settings sourceLanguageTag & languageTags. Possible language tags are ${allLanguageTags}.`
+			)
+			return
+		}
 
-		log.info(`📝 Translating to ${languagesTagsToTranslateTo.length} languages.`)
+		const targetLanguageTags: ProjectSettings["languageTags"] = options.targetLanguageTags
+			? options.targetLanguageTags[0]?.split(",")
+			: projectConfig.languageTags
+		if (!targetLanguageTags) {
+			log.error(
+				`No language tags defined. Please define languageTags in the project.inlang.json file or as an argument with --targetLanguageTags.`
+			)
+			return
+		}
+		if (
+			options.targetLanguageTags &&
+			!targetLanguageTags.every((tag) => allLanguageTags.includes(tag))
+		) {
+			log.error(
+				`Some or all of the language tags "${options.targetLanguageTags}" are not included in the project settings sourceLanguageTag & languageTags. Possible language tags are ${allLanguageTags}.`
+			)
+			return
+		}
+
+		log.info(`📝 Translating to ${targetLanguageTags.length} languages.`)
 
 		// parallelize in the future
 		for (const id of args.project.query.messages.includedMessageIds()) {
 			const { data: translatedMessage, error } = await rpc.machineTranslateMessage({
 				message: args.project.query.messages.get({ where: { id } })!,
-				sourceLanguageTag: sourceLanguageTag,
-				targetLanguageTags: languagesTagsToTranslateTo,
+				sourceLanguageTag,
+				targetLanguageTags,
 			})
 			if (error) {
 				log.error(`Couldn't translate message "${id}": ${error}`)


### PR DESCRIPTION
This PR aims to add `sourceLanguageTag` & `targetLanguageTags` options to `machine translate` command

Try it with `npx ./inlang/source-code/cli machine translate --targetLanguageTags=zh,pt-BR`

fix #1734 