### PR TITLE
Add `isAvailableLanguageTag` convenience function to paraglide

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @inlang/paraglide-js
 
+## 1.0.0-prerelease.13
+
+`./paraglide/runtime.js` now exports a function called `isAvailableLanguageTag`. This is 
+the recommended way to check if something is a valid language tag, while maintaining
+type safety. 
+
+```ts
+//Pseudo code
+import { isAvailableLanguageTag } from "./paraglide/runtime"
+
+if (isAvailableLanguageTag(params.lang)) {
+   	return renderSite(params.lang)
+} else {
+	return 404
+}
+``` 
+
 ## 1.0.0-prerelease.12
 
 [Internal Change]

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.12",
+	"version": "1.0.0-prerelease.13",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -251,6 +251,23 @@ describe("e2e", async () => {
 			"Hallo Samuel! Du hast 5 Nachrichten."
 		)
 	})
+
+	test("runtime.isAvailableLanguageTag should only return `true` if a language tag is passed to it", async () => {
+		const { runtime } = await import(
+			`data:application/javascript;base64,${Buffer.from(
+				compiledBundle.output[0].code,
+				"utf8"
+			).toString("base64")}`
+		)
+
+		for (const tag of runtime.availableLanguageTags) {
+			expect(runtime.isAvailableLanguageTag(tag)).toBe(true)
+		}
+
+		expect(runtime.isAvailableLanguageTag("")).toBe(false)
+		expect(runtime.isAvailableLanguageTag("pl")).toBe(false)
+		expect(runtime.isAvailableLanguageTag("--")).toBe(false)
+	})
 })
 
 describe("tree-shaking", () => {
@@ -385,6 +402,15 @@ test("typesafety", async () => {
 
 	// setting the language tag as a getter function should be possible
 	runtime.setLanguageTag(() => "en")
+
+	// isAvailableLanguageTag should narrow the type of it's argument
+	const thing = 5;
+	if(runtime.isAvailableLanguageTag(thing)) {
+		const a : "de" | "en" | "en-US" = thing
+	} else {
+		// @ts-expect-error - thing is not a language tag
+		const a : "de" | "en" | "en-US" = thing
+	}
 
     // --------- MESSAGES ---------
 

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
@@ -188,6 +188,23 @@ export const onSetLanguageTag = (fn) => {
 	_onSetLanguageTag = fn
 }
 
+/**
+ * Check if something is an available language tag.
+ * 
+ * @example
+ * 	if (isAvailableLanguageTag(params.locale)) {
+ * 		setLanguageTag(params.locale)
+ * 	} else {
+ * 		setLanguageTag("en")
+ * 	}
+ * 
+ * @param {any} thing
+ * @returns {thing is AvailableLanguageTag}
+ */
+export function isAvailableLanguageTag(thing) {
+	return availableLanguageTags.includes(thing)
+}
+
 // ------ TYPES ------
 
 /**


### PR DESCRIPTION
Closes #1729 

This PR adds a function called `isAvailableLanguageTag` to paraglide's runtime, that allows users to check if some variable is an availableLanguageTag. 

A common use-case for this is checking if some url parameter matches one of an app's languages.

It's inconvenient to just use `availableLanguageTags.includes( thing )`, for the reasons described in  #1729 