### PR TITLE
Use named export for Webpack plugin

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-webpack/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-webpack/README.md
@@ -32,7 +32,7 @@ Since you will be importing from the `paraglide` folder a lot, it's a good idea 
 In your `webpack.config.js`, add an alias to your `resolve` object:
 
 ```js
-import Paraglide from "@inlang/paraglide-js-adapter-webpack";
+import { paraglide } from "@inlang/paraglide-js-adapter-webpack";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -45,7 +45,7 @@ export default {
 		}
 	},
   plugins: [
-		Paraglide({
+		paraglide({
 			project: "./project.inlang.json",
 			outdir: "./src/paraglide",
 		}),

--- a/inlang/source-code/paraglide/paraglide-js-adapter-webpack/example/webpack.config.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-webpack/example/webpack.config.js
@@ -1,6 +1,6 @@
 import path from "path"
 import { fileURLToPath } from "url"
-import Paraglide from "@inlang/paraglide-js-adapter-webpack"
+import { paraglide } from "@inlang/paraglide-js-adapter-webpack"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -18,7 +18,7 @@ export default {
 	},
 
 	plugins: [
-		Paraglide({
+		paraglide({
 			project: "./project.inlang.json",
 			outdir: "./src/paraglide",
 		}),

--- a/inlang/source-code/paraglide/paraglide-js-adapter-webpack/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-webpack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inlang/paraglide-js-adapter-webpack",
-    "version": "1.0.0-prerelease.2",
+    "version": "1.0.0-prerelease.3",
     "description": "Webpack adapter for Paraglide.js",
     "license": "Apache-2.0",
     "type": "module",

--- a/inlang/source-code/paraglide/paraglide-js-adapter-webpack/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-webpack/src/index.ts
@@ -2,5 +2,15 @@ import {
 	paraglide as unpluginParaglide,
 	type UserConfig,
 } from "@inlang/paraglide-js-adapter-unplugin"
-const paraglide: (config: UserConfig) => any = unpluginParaglide.webpack
-export default paraglide
+
+export const paraglide: (config: UserConfig) => any = unpluginParaglide.webpack
+
+/**
+ * @deprecated - Please use the named export '{ paraglide }' instead.
+ */
+export default (config: UserConfig) => {
+	console.warn(
+		"The default export of `@inlang/paraglide-js-adapter-webpack` is deprecated.\nPlease use the named export '{ paraglide }' instead."
+	)
+	return paraglide(config)
+}


### PR DESCRIPTION
Closes #1761 

This PR updates the webpack plugin to also use a named export `{ paraglide }`, bringing it inline with the other bundler plugins.
To not break any existing apps, the default export still works, but it's marked as depreciated and logs a warning when used, prompting users to switch to the default export