### PR TITLE
[Fix] Fix paraglide init when using vscode

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @inlang/paraglide-js
 
+## 1.0.0-prerelease.15
+
+Fix crash when using `npx @inlang/paraglide-js init` and selecting vscode.
+
 ## 1.0.0-prerelease.14
 
 Added `--watch` flag to the `paraglide-js compile` command. This will keep the process alive and recompile whenever messages are changed. 

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.14",
+	"version": "1.0.0-prerelease.15",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
@@ -142,7 +142,7 @@ describe("addCompileStepToPackageJSON()", () => {
 		})
 		await addCompileStepToPackageJSON(
 			{
-				projectPath: "./project.inlang.json",
+				projectPath: "./project.inlang",
 			},
 			logger
 		)
@@ -152,7 +152,7 @@ describe("addCompileStepToPackageJSON()", () => {
 			(await fs.readFile("/package.json", { encoding: "utf-8" })) as string
 		)
 		expect(packageJson.scripts.build).toBe(
-			`paraglide-js compile --project ./project.inlang.json && some build step`
+			`paraglide-js compile --project ./project.inlang && some build step`
 		)
 	})
 
@@ -160,7 +160,7 @@ describe("addCompileStepToPackageJSON()", () => {
 		mockFiles({
 			"/package.json": JSON.stringify({
 				scripts: {
-					build: "paraglide-js compile --project ./project.inlang.json",
+					build: "paraglide-js compile --project ./project.inlang",
 				},
 			}),
 		})
@@ -170,7 +170,7 @@ describe("addCompileStepToPackageJSON()", () => {
 		])
 		await addCompileStepToPackageJSON(
 			{
-				projectPath: "./project.inlang.json",
+				projectPath: "./project.inlang",
 			},
 			logger
 		)
@@ -184,7 +184,7 @@ describe("addCompileStepToPackageJSON()", () => {
 		mockFiles({
 			"/package.json": JSON.stringify({
 				scripts: {
-					build: "paraglide-js compile --project ./project.inlang.json",
+					build: "paraglide-js compile --project ./project.inlang",
 				},
 			}),
 		})
@@ -194,7 +194,7 @@ describe("addCompileStepToPackageJSON()", () => {
 		])
 		await addCompileStepToPackageJSON(
 			{
-				projectPath: "./project.inlang.json",
+				projectPath: "./project.inlang",
 			},
 			logger
 		)
@@ -243,13 +243,13 @@ describe("existingProjectFlow()", () => {
 describe("maybeAddVsCodeExtension()", () => {
 	test("it should add the vscode extension if the user uses vscode", async () => {
 		mockFiles({
-			"/project.inlang.json": JSON.stringify(newProjectTemplate),
+			"/project.inlang/settings.json": JSON.stringify(newProjectTemplate),
 		})
 		mockUserInput([
 			// user uses vscode
 			true,
 		])
-		await maybeAddVsCodeExtension({ projectPath: "/project.inlang.json" }, logger)
+		await maybeAddVsCodeExtension({ projectPath: "/project.inlang" }, logger)
 		expect(consola.prompt).toHaveBeenCalledOnce()
 		const extensions = await fs.readFile("/.vscode/extensions.json", {
 			encoding: "utf-8",
@@ -266,13 +266,13 @@ describe("maybeAddVsCodeExtension()", () => {
 	})
 	test("it should not add the vscode extension if the user doesn't use vscode", async () => {
 		mockFiles({
-			"/project.inlang.json": JSON.stringify(newProjectTemplate),
+			"/project.inlang/settings.json": JSON.stringify(newProjectTemplate),
 		})
 		mockUserInput([
 			// user does not use vscode
 			false,
 		])
-		await maybeAddVsCodeExtension({ projectPath: "/project.inlang.json" }, logger)
+		await maybeAddVsCodeExtension({ projectPath: "/project.inlang" }, logger)
 		expect(consola.prompt).toHaveBeenCalledOnce()
 		expect(fs.writeFile).not.toHaveBeenCalled()
 	})
@@ -281,15 +281,15 @@ describe("maybeAddVsCodeExtension()", () => {
 		const withEmptyModules = structuredClone(newProjectTemplate)
 		withEmptyModules.modules = []
 		mockFiles({
-			"/project.inlang.json": JSON.stringify(withEmptyModules),
+			"/project.inlang/settings.json": JSON.stringify(withEmptyModules),
 		})
 		mockUserInput([
 			// user uses vscode
 			true,
 		])
-		await maybeAddVsCodeExtension({ projectPath: "/project.inlang.json" }, logger)
+		await maybeAddVsCodeExtension({ projectPath: "/project.inlang" }, logger)
 		const projectSettings = JSON.parse(
-			await fs.readFile("/project.inlang.json", {
+			await fs.readFile("/project.inlang/settings.json", {
 				encoding: "utf-8",
 			})
 		) as ProjectSettings
@@ -297,13 +297,13 @@ describe("maybeAddVsCodeExtension()", () => {
 	})
 	test("it should create the .vscode folder if not existent", async () => {
 		mockFiles({
-			"/project.inlang.json": JSON.stringify(newProjectTemplate),
+			"/project.inlang/settings.json": JSON.stringify(newProjectTemplate),
 		})
 		mockUserInput([
 			// user uses vscode
 			true,
 		])
-		await maybeAddVsCodeExtension({ projectPath: "/project.inlang.json" }, logger)
+		await maybeAddVsCodeExtension({ projectPath: "/project.inlang" }, logger)
 		expect(fsSync.existsSync("/.vscode/extensions.json")).toBe(true)
 	})
 })
@@ -412,7 +412,7 @@ describe("checkIfPackageJsonExists()", () => {
 })
 
 describe("findExistingInlangProjectPath()", () => {
-	test("it should return undefined if no project.inlang.json has been found", async () => {
+	test("it should return undefined if no project.inlang has been found", async () => {
 		mockFiles({})
 		const path = await findExistingInlangProjectPath()
 		expect(path).toBeUndefined()

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -62,9 +62,13 @@ export const maybeAddVsCodeExtension = async (args: { projectPath: string }, log
 		return
 	}
 
-	const file = await fs.readFile(args.projectPath, { encoding: "utf-8" })
-	const stringify = detectJsonFormatting(file)
-	const settings = JSON.parse(file) as ProjectSettings
+	const project = await loadProject({
+		projectPath: resolve(process.cwd(), args.projectPath),
+		//@ts-ignore
+		nodeishFs: fs,
+	})
+
+	const settings = project.settings()
 
 	// m function matcher is not installed
 	if (settings.modules.some((m) => m.includes("plugin-m-function-matcher")) === false) {
@@ -72,7 +76,7 @@ export const maybeAddVsCodeExtension = async (args: { projectPath: string }, log
 		settings.modules.push(
 			"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
 		)
-		await fs.writeFile(args.projectPath, stringify(settings))
+		project.setSettings(settings)
 	}
 	let extensions: any = {}
 	try {

--- a/inlang/source-code/website/src/renderer/Link.tsx
+++ b/inlang/source-code/website/src/renderer/Link.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { languageTag, sourceLanguageTag } from "#src/paraglide/runtime.js"
 
 const Link = (props: { href?: string; [key: string]: any }) => {

--- a/inlang/source-code/website/src/renderer/Link.tsx
+++ b/inlang/source-code/website/src/renderer/Link.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { languageTag, sourceLanguageTag } from "#src/paraglide/runtime.js"
 
 const Link = (props: { href?: string; [key: string]: any }) => {


### PR DESCRIPTION
This PR fixes a crash when running `paraglide init` and selecting vscode. 
This happend because it was trying to read the project directory as if it was the old `project.inlang.json` file. Some of the tests didn't get updated properly and were still using the `project.inlang.json` file (probably merge issues), so the test didn't catch this. 

Both are fixed in this PR