### PR TITLE
[Website] Allow Card Titles to have two lines

### DIFF
--- a/inlang/source-code/website/src/interface/components/Card.tsx
+++ b/inlang/source-code/website/src/interface/components/Card.tsx
@@ -31,7 +31,7 @@ export default function Card(props: { item: any; displayName: string }) {
 				}
 				class={
 					"relative no-underline z-10 flex justify-between gap-4 overflow-hidden flex-col group w-full bg-background transition-all border border-surface-200 rounded-xl hover:shadow-lg hover:shadow-surface-100 hover:border-surface-300 active:border-surface-400 " +
-					(showCover || app ? " " : " h-48 p-5")
+					(showCover || app ? " " : /* min-h-48 */ " min-h-[12rem] p-5")
 				}
 			>
 				<Switch>
@@ -128,7 +128,10 @@ export default function Card(props: { item: any; displayName: string }) {
 									</Show>
 								</div>
 								<div class="flex flex-col justify-between items-start">
-									<p class="m-0 mb-2 text-sm text-surface-800 line-clamp-1 leading-none no-underline font-semibold group-hover:text-surface-900 transition-colors">
+									<p
+										style="text-wrap: balance;"
+										class="m-0 mb-2 text-sm text-surface-800 line-clamp-2 leading-none no-underline font-semibold group-hover:text-surface-900 transition-colors"
+									>
 										{props.displayName}
 									</p>
 									<Chip

--- a/inlang/source-code/website/src/interface/components/Card.tsx
+++ b/inlang/source-code/website/src/interface/components/Card.tsx
@@ -129,6 +129,7 @@ export default function Card(props: { item: any; displayName: string }) {
 								</div>
 								<div class="flex flex-col justify-between items-start">
 									<p
+										// eslint-disable-next-line solid/style-prop
 										style="text-wrap: balance;"
 										class="m-0 mb-2 text-sm text-surface-800 line-clamp-2 leading-none no-underline font-semibold group-hover:text-surface-900 transition-colors"
 									>


### PR DESCRIPTION
This PR changes the line-clamp on the card titles from one to two.

Having just one line is insufficient for a properly descriptive title. Important information either had to be omitted (bad for SEO), or we had to accept that it would cut off (bad UX). 

With the two-line titles we now have a litte more space.

![Screenshot 2023-12-05 at 09 23 08](https://github.com/inlang/monorepo/assets/43482866/32069e76-24d0-4628-9e79-4ce4592d0454)

Using `text-wrap: balance` makes the wrapping a little nicer.

https://github.com/inlang/monorepo/assets/43482866/2b5d5207-d3f9-4905-89bb-7122ac6c10fa

