### PR TITLE
Minor Cleanup for the Solid Adapter

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/example/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/example/package.json
@@ -4,9 +4,8 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"paraglide": "paraglide-js compile --project ./project.inlang",
-		"dev": "pnpm run paraglide --watch & solid-start dev",
-		"build": "pnpm run paraglide && solid-start build",
+		"_dev": "solid-start dev",
+		"build": "solid-start build",
 		"start": "solid-start start"
 	},
 	"dependencies": {
@@ -17,9 +16,10 @@
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "workspace:*",
+		"@inlang/paraglide-js-adapter-vite": "workspace:*",
+		"@types/node": "^20",
 		"solid-start-node": "^0.3",
-		"vite": "^4",
 		"typescript": "^5",
-		"@types/node": "^20"
+		"vite": "^4"
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/example/vite.config.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/example/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vite"
 import solid from "solid-start/vite"
 import nodeAdapter from "solid-start-node"
+import { paraglide } from "@inlang/paraglide-js-adapter-vite"
 
 export default defineConfig({
-	plugins: [solid({ adapter: nodeAdapter() })],
+	plugins: [
+		solid({ adapter: nodeAdapter() }),
+		paraglide({
+			project: "./project.inlang",
+			outdir: "./src/paraglide",
+		}),
+	],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1095,6 +1095,9 @@ importers:
       '@inlang/paraglide-js':
         specifier: workspace:*
         version: link:../../paraglide-js
+      '@inlang/paraglide-js-adapter-vite':
+        specifier: workspace:*
+        version: link:../../paraglide-js-adapter-vite
       '@types/node':
         specifier: ^20
         version: 20.9.3


### PR DESCRIPTION
@thetarnav just merged the solidstart adapter 🎉

This PR does some minor modifications to bring the setup more inline with the other adapters.
- Use `@inlang/paraglide-js-adapter-vite` for running the paraglide commands
- Simplify command setup
- Use `_dev` instead of `dev` to avoid the example project being run when the global `dev` command is used