### PR TITLE
`paraglide-js init` add `paraglide-js compile` to  `postinstall` instead of `lint` script

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -8,7 +8,7 @@ Fix `paraglide compile` hanging for a couple seconds after successful compilatio
 
 Fix crash when using `npx @inlang/paraglide-js init` and selecting vscode.
 
-## 1.0.0-prerelease.14
+## 1.0.0-prerelease.14
 
 Added `--watch` flag to the `paraglide-js compile` command. This will keep the process alive and recompile whenever messages are changed. 
 
@@ -17,7 +17,7 @@ paraglide-js compile --project ./project.inlang --watch
 ```
 
 
-## 1.0.0-prerelease.13
+## 1.0.0-prerelease.13
 
 `./paraglide/runtime.js` now exports a function called `isAvailableLanguageTag`. This is 
 the recommended way to check if something is a valid language tag, while maintaining
@@ -34,7 +34,7 @@ if (isAvailableLanguageTag(params.lang)) {
 }
 ``` 
 
-## 1.0.0-prerelease.12
+## 1.0.0-prerelease.12
 
 [Internal Change]
 Expose the compiler so that bundler plugins can call it programmatically instead of going through the CLI.

--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @inlang/paraglide-js
 
+## 1.0.0-prerelease.17
+
+`paraglide init` now adds `paraglide compile` to the postinstall script by default. This sidesteps numerous linting issues when using paraglide in CI environments. 
+
 ## 1.0.0-prerelease.16
 
 Fix `paraglide compile` hanging for a couple seconds after successful compilation 

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.16",
+	"version": "1.0.0-prerelease.17",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
@@ -204,11 +204,11 @@ describe("addCompileStepToPackageJSON()", () => {
 		expect(process.exit).not.toHaveBeenCalled()
 	})
 
-	test("if there is a lint script present, add the paraglide-js compile command to it", async () => {
+	test("if there is a postinstall script present, add the paraglide-js compile command to it", async () => {
 		mockFiles({
 			"/package.json": JSON.stringify({
 				scripts: {
-					lint: "eslint",
+					postinstall: "do-something",
 				},
 			}),
 		})
@@ -228,16 +228,16 @@ describe("addCompileStepToPackageJSON()", () => {
 		const packageJson = JSON.parse(
 			(await fs.readFile("/package.json", { encoding: "utf-8" })) as string
 		)
-		expect(packageJson.scripts.lint).toBe(
-			`paraglide-js compile --project ./project.inlang && eslint`
+		expect(packageJson.scripts.postinstall).toBe(
+			`paraglide-js compile --project ./project.inlang && do-something`
 		)
 	})
 
-	test("if there is a lint script present, but it already has a paraglide command, leave it as is", async () => {
+	test("if there is a postinstall script present, but it already has a paraglide command, leave it as is", async () => {
 		mockFiles({
 			"/package.json": JSON.stringify({
 				scripts: {
-					lint: "paraglide-js compile && eslint",
+					postinstall: "paraglide-js compile && do-something",
 				},
 			}),
 		})
@@ -254,7 +254,27 @@ describe("addCompileStepToPackageJSON()", () => {
 		const packageJson = JSON.parse(
 			(await fs.readFile("/package.json", { encoding: "utf-8" })) as string
 		)
-		expect(packageJson.scripts.lint).toBe(`paraglide-js compile && eslint`)
+		expect(packageJson.scripts.postinstall).toBe(`paraglide-js compile && do-something`)
+	})
+
+	test("if there is no postinstall script present add the paragldie compile command", async () => {
+		mockFiles({
+			"/package.json": JSON.stringify({}),
+		})
+		mockUserInput([
+			// user does not want to update the build step
+			false,
+		])
+		await addCompileStepToPackageJSON(
+			{
+				projectPath: "./project.inlang",
+			},
+			logger
+		)
+		const packageJson = JSON.parse(
+			(await fs.readFile("/package.json", { encoding: "utf-8" })) as string
+		)
+		expect(packageJson.scripts.postinstall).toBe(`paraglide-js compile --project ./project.inlang`)
 	})
 })
 

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -244,16 +244,20 @@ export const addCompileStepToPackageJSON = async (
 	const stringify = detectJsonFormatting(file)
 	const pkg = JSON.parse(file)
 
-	// add the compile command to the lint script if it exists
-	// this isn't super important, so we won't interrupt the user if it fails
-	if (pkg?.scripts?.lint && pkg.scripts.lint.includes("paraglide-js compile") === false) {
-			pkg.scripts.lint = `paraglide-js compile --project ${args.projectPath} && ${pkg.scripts.lint}`
-		}
+	if (pkg.scripts === undefined) {
+		pkg.scripts = {}
+	}
 
+	// add the compile command to the postinstall script
+	// this isn't super important, so we won't interrupt the user if it fails
+	if (!pkg.scripts.postinstall) {
+		pkg.scripts.postinstall = `paraglide-js compile --project ${args.projectPath}`
+	} else if (pkg.scripts.postinstall.includes("paraglide-js compile") === false) {
+		pkg.scripts.postinstall = `paraglide-js compile --project ${args.projectPath} && ${pkg.scripts.postinstall}`
+	}
+
+	//Add the compile command to the build script
 	if (pkg?.scripts?.build === undefined) {
-		if (pkg.scripts === undefined) {
-			pkg.scripts = {}
-		}
 		pkg.scripts.build = `paraglide-js compile --project ${args.projectPath}`
 	} else if (pkg?.scripts?.build.includes("paraglide-js compile") === false) {
 		pkg.scripts.build = `paraglide-js compile --project ${args.projectPath} && ${pkg.scripts.build}`


### PR DESCRIPTION
This PR changes the behaviour of `paraglide init` to add the `paraglide compile` command to the `postinstall` script, instead of the `lint` script. This should fix the CI issues described in #1799 in the same way, but regardless of specific script names. 

If paraglide is being run in a CI environment where `npm build` isn't explicitly called during build (like in [EAS](https://expo.dev) Builds) running paraglide in the postinstall script is also required. I don't see any harm in doing this.

The `lint` thing didn't get published yet, so this is a harmless fix.