### PR TITLE
[Paraglide] Check if files would change before writing

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.test.ts
@@ -73,34 +73,35 @@ test("it should compile into the default outdir", async () => {
 	expect(_fs.existsSync("./src/paraglide/messages.js")).toBe(true)
 })
 
-test("it should compile a project into the provided outdir", async () => {
+test.only("it should compile a project into the provided outdir", async () => {
 	const outdirs = ["/paraglide-js", "./paraglide-js", "/src/paraglide-js", "./src/paraglide-js"]
 
+	const _fs = mockFs({
+		"/plugin.js": fs.readFileSync(
+			// using the inlang-message-format plugin
+			resolve(__dirname, "../../../../../plugins/inlang-message-format/dist/index.js"),
+			{ encoding: "utf-8" }
+		),
+		"/project.inlang/settings.json": JSON.stringify({
+			sourceLanguageTag: "en",
+			languageTags: ["de", "en"],
+			modules: ["/plugin.js"],
+			"plugin.inlang.messageFormat": {
+				pathPattern: "/messages/{languageTag}.json",
+			},
+		} satisfies ProjectSettings),
+		"/messages.json": JSON.stringify({
+			$schema: "https://inlang.com/schema/inlang-message-format",
+			data: [
+				createMessage("loginButton", {
+					en: "Login",
+					de: "Anmelden",
+				}),
+			],
+		}),
+	})
+
 	for (const outdir of outdirs) {
-		const _fs = mockFs({
-			"/plugin.js": fs.readFileSync(
-				// using the inlang-message-format plugin
-				resolve(__dirname, "../../../../../plugins/inlang-message-format/dist/index.js"),
-				{ encoding: "utf-8" }
-			),
-			"/project.inlang/settings.json": JSON.stringify({
-				sourceLanguageTag: "en",
-				languageTags: ["de", "en"],
-				modules: ["/plugin.js"],
-				"plugin.inlang.messageFormat": {
-					pathPattern: "/messages/{languageTag}.json",
-				},
-			} satisfies ProjectSettings),
-			"/messages.json": JSON.stringify({
-				$schema: "https://inlang.com/schema/inlang-message-format",
-				data: [
-					createMessage("loginButton", {
-						en: "Login",
-						de: "Anmelden",
-					}),
-				],
-			}),
-		})
 		// I have no idea why, but the { from: "user" } is required for the test to pass
 		await compileCommand.parseAsync(["--project", "./project.inlang", "--outdir", outdir], {
 			from: "user",

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile.test.ts
@@ -73,7 +73,7 @@ test("it should compile into the default outdir", async () => {
 	expect(_fs.existsSync("./src/paraglide/messages.js")).toBe(true)
 })
 
-test.only("it should compile a project into the provided outdir", async () => {
+test("it should compile a project into the provided outdir", async () => {
 	const outdirs = ["/paraglide-js", "./paraglide-js", "/src/paraglide-js", "./src/paraglide-js"]
 
 	const _fs = mockFs({

--- a/inlang/source-code/paraglide/paraglide-js/src/services/file-handling/write-output.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/file-handling/write-output.ts
@@ -1,14 +1,17 @@
 import type nodeFsPromises from "node:fs/promises"
 import path from "node:path"
+import crypto from "node:crypto"
+
+let previousOutputHash: string | undefined
 
 export async function writeOutput(
 	outputDirectory: string,
 	output: Record<string, string>,
 	fs: typeof nodeFsPromises
 ) {
-	//Bail if the output directory already contains identical files
-	const existing = await readCurrentOutputDirectory(outputDirectory, fs)
-	if (recordsAreEqual(existing, output)) return
+	// if the output hasn't changed, don't write it
+	const currentOutputHash = hashOutput(output, outputDirectory)
+	if (currentOutputHash === previousOutputHash) return
 
 	// create the output directory if it doesn't exist
 	await fs.access(outputDirectory).catch(async () => {
@@ -42,65 +45,14 @@ export async function writeOutput(
 			})
 		})
 	)
+
+	//Only update the previousOutputHash if the write was successful
+	previousOutputHash = currentOutputHash
 }
 
-/**
- * Performs a shallow comparison of two records by comparing their top level keys and values
- */
-function recordsAreEqual(a: Record<string, string>, b: Record<string, string>): boolean {
-	const aKeys = Object.keys(a)
-	const bKeys = Object.keys(b)
-
-	if (aKeys.length !== bKeys.length) {
-		return false
-	}
-
-	for (const key of aKeys) {
-		if (a[key] !== b[key]) {
-			return false
-		}
-	}
-
-	return true
-}
-
-/**
- * Tries to recursively read the current output directory and returns a map of all files and their content
- * If the output directory does not exist, it returns an empty map
- *
- *
- * @example
- * ```ts
- * const output = await readCurrentOutputDirectory(outputDirectory, fs)
- *
- * // output = {
- * //   "runtime.js": "...",
- * //   "messages.js": "...",
- * //   "messages/de.js": "...",
- * //   "messages/en.js": "...",
- * ```
- *
- */
-async function readCurrentOutputDirectory(
-	outputDirectory: string,
-	fs: typeof nodeFsPromises
-): Promise<Record<string, string>> {
-	try {
-		const files = await fs.readdir(outputDirectory, { recursive: true })
-		const output: Record<string, string> = {}
-
-		await Promise.allSettled(
-			files.map(async (file) => {
-				const filePath = path.resolve(outputDirectory, file)
-				const fileContent = await fs.readFile(filePath, {
-					encoding: "utf-8",
-				})
-				output[file] = fileContent
-			})
-		)
-
-		return output
-	} catch (e) {
-		return {}
-	}
+function hashOutput(output: Record<string, string>, outputDirectory: string): string {
+	const hash = crypto.createHash("sha256")
+	hash.update(JSON.stringify(output))
+	hash.update(outputDirectory)
+	return hash.digest("hex")
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/services/file-handling/write-output.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/file-handling/write-output.ts
@@ -1,7 +1,6 @@
 import type nodeFsPromises from "node:fs/promises"
 import path from "node:path"
 
-
 export async function writeOutput(
 	outputDirectory: string,
 	output: Record<string, string>,

--- a/inlang/source-code/paraglide/paraglide-js/src/services/file-handling/write-output.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/services/file-handling/write-output.ts
@@ -1,11 +1,16 @@
 import type nodeFsPromises from "node:fs/promises"
 import path from "node:path"
 
+
 export async function writeOutput(
 	outputDirectory: string,
 	output: Record<string, string>,
 	fs: typeof nodeFsPromises
 ) {
+	//Bail if the output directory already contains identical files
+	const existing = await readCurrentOutputDirectory(outputDirectory, fs)
+	if (recordsAreEqual(existing, output)) return
+
 	// create the output directory if it doesn't exist
 	await fs.access(outputDirectory).catch(async () => {
 		await fs.mkdir(outputDirectory, { recursive: true })
@@ -38,4 +43,65 @@ export async function writeOutput(
 			})
 		})
 	)
+}
+
+/**
+ * Performs a shallow comparison of two records by comparing their top level keys and values
+ */
+function recordsAreEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+	const aKeys = Object.keys(a)
+	const bKeys = Object.keys(b)
+
+	if (aKeys.length !== bKeys.length) {
+		return false
+	}
+
+	for (const key of aKeys) {
+		if (a[key] !== b[key]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+/**
+ * Tries to recursively read the current output directory and returns a map of all files and their content
+ * If the output directory does not exist, it returns an empty map
+ *
+ *
+ * @example
+ * ```ts
+ * const output = await readCurrentOutputDirectory(outputDirectory, fs)
+ *
+ * // output = {
+ * //   "runtime.js": "...",
+ * //   "messages.js": "...",
+ * //   "messages/de.js": "...",
+ * //   "messages/en.js": "...",
+ * ```
+ *
+ */
+async function readCurrentOutputDirectory(
+	outputDirectory: string,
+	fs: typeof nodeFsPromises
+): Promise<Record<string, string>> {
+	try {
+		const files = await fs.readdir(outputDirectory, { recursive: true })
+		const output: Record<string, string> = {}
+
+		await Promise.allSettled(
+			files.map(async (file) => {
+				const filePath = path.resolve(outputDirectory, file)
+				const fileContent = await fs.readFile(filePath, {
+					encoding: "utf-8",
+				})
+				output[file] = fileContent
+			})
+		)
+
+		return output
+	} catch (e) {
+		return {}
+	}
 }


### PR DESCRIPTION
This PR adds a check to see if the expected files already exist before writing to the output directory.

It currently does not include an automated test for if the skipping works, because of [streamich/memfs#967](https://github.com/streamich/memfs/issues/967), but manual testing / logging says it works!