### PR TITLE
Fix typo in package and marketplace manifest files

### DIFF
--- a/inlang/source-code/message-lint-rules/validJsIdentifier/CHANGELOG.md
+++ b/inlang/source-code/message-lint-rules/validJsIdentifier/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ### Major Changes
 
-- add `@inlang/message-lint-rule-vaild-js-identifier`
+- add `@inlang/message-lint-rule-valid-js-identifier`
   Check that all message ids are valid & non-reserved JS identifiers.

--- a/inlang/source-code/message-lint-rules/validJsIdentifier/marketplace-manifest.json
+++ b/inlang/source-code/message-lint-rules/validJsIdentifier/marketplace-manifest.json
@@ -24,5 +24,5 @@
 	"publisherName": "inlang",
 	"publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
 	"license": "Apache-2.0",
-	"module": "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-vaild-js-identifier@latest/dist/index.js"
+	"module": "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@latest/dist/index.js"
 }

--- a/inlang/source-code/message-lint-rules/validJsIdentifier/package.json
+++ b/inlang/source-code/message-lint-rules/validJsIdentifier/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@inlang/message-lint-rule-vaild-js-identifier",
+	"name": "@inlang/message-lint-rule-valid-js-identifier",
 	"version": "1.0.0",
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
This is a bit awkward, I misspelled the package name for `@inlang/message-lint-rule-valid-js-identifier`. 
I spelled "valid" as "vaild"

This PR fixes that. No one has used the misspelled version yet, so we're good. 

I'll delete the misspelled package from npm after this