### PR TITLE
Paraglide Init: Add `@inlang/message-lint-rule-valid-js-identifier` by default

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,12 +1,16 @@
 # @inlang/paraglide-js
 
+## 1.0.0-prerelease.18
+
+`paraglide-js init` now adds `@inlang/message-lint-rule-valid-js-identifier` by default.
+
 ## 1.0.0-prerelease.17
 
-`paraglide init` now adds `paraglide compile` to the postinstall script by default. This sidesteps numerous linting issues when using paraglide in CI environments. 
+`paraglide-js init` now adds `paraglide-js compile` to the postinstall script by default. This sidesteps numerous linting issues when using paraglide in CI environments. 
 
 ## 1.0.0-prerelease.16
 
-Fix `paraglide compile` hanging for a couple seconds after successful compilation 
+Fix `paraglide-js compile` hanging for a couple seconds after successful compilation 
 
 ## 1.0.0-prerelease.15
 

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.17",
+	"version": "1.0.0-prerelease.18",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"

--- a/inlang/source-code/paraglide/paraglide-js/project.inlang.json
+++ b/inlang/source-code/paraglide/paraglide-js/project.inlang.json
@@ -9,6 +9,7 @@
     "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js",
     "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
     "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@latest/dist/index.js",
     "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
   ],
   "plugin.inlang.messageFormat": {

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -188,6 +188,7 @@ export const newProjectTemplate: ProjectSettings = {
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@latest/dist/index.js",
 		// default to the message format plugin because it supports all features
 		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js",
 		// the m function matcher should be installed by default in case the ide extension is adopted


### PR DESCRIPTION
This PR updates the `paraglide-js init` command to add the `@inlang/message-lint-rule-valid-js-identifier` lint rule by default, since anything that doesn't pass that rule cannot be used with paraglide anyways. 