### PR TITLE
[Website] Make Solid category prettier

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/README.md
@@ -113,4 +113,4 @@ If you want to navigate to a different route in a specific language, you can use
 <A href={translateHref("/about", "en")}>{m.about()}</A>
 ```
 
-> :warning: Don't use the `translateHref` function on links that point to external websites. It will break the link.
+> ⚠️ Don't use the `translateHref` function on links that point to external websites. It will break the link.

--- a/inlang/source-code/paraglide/paraglide-js/README.md
+++ b/inlang/source-code/paraglide/paraglide-js/README.md
@@ -46,7 +46,7 @@ Having an adapter is only required if you want to use paraglide-js with a framew
 
 <doc-links>
     <doc-link title="Adapter for Svelte" icon="simple-icons:svelte" href="https://github.com/inlang/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-svelte/example" description="Go to GitHub example"></doc-link>
-    <doc-link title="Adapter for SolidJS" icon="tabler:brand-solidjs" href="https://github.com/inlang/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-solidstart" description="Go to Github"></doc-link>
+    <doc-link title="Adapter for SolidJS" icon="tabler:brand-solidjs" href="https://inlang.com/m/n860p17j/library-inlang-paraglideJsAdapterSolidStart" description="Go to Adapter"></doc-link>
     <doc-link title="Adapter for NextJS" icon="tabler:brand-nextjs" href="https://github.com/inlang/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-next" description="Go to GitHub example"></doc-link>
     <doc-link title="Adapter for Vite" icon="tabler:brand-vite" href="https://github.com/inlang/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-vite" description="Go to GitHub"></doc-link>
 </doc-links>

--- a/inlang/source-code/website/src/pages/c/@category/index.page.tsx
+++ b/inlang/source-code/website/src/pages/c/@category/index.page.tsx
@@ -118,6 +118,15 @@ export function Page(props: {
 					withGuides: true,
 					coverCard: <NextjsHeader />,
 				}
+
+			case "solid": {
+				return {
+					title: "Solid",
+					description: "Recommended internationalization tooling for your SolidStart stack.",
+					icon: "https://cdn.jsdelivr.net/gh/inlang/monorepo@latest/inlang/source-code/paraglide/paraglide-js-adapter-solidstart/assets/icon.png",
+					coverCard: <GenericHeader />,
+				}
+			}
 			default:
 				return {
 					title: currentPageContext.urlParsed.pathname.split("/")[2]?.toUpperCase() || "Your stack",


### PR DESCRIPTION
This PR adds an Icon & customised text to the Solid Category, to make it seem a bit more polished. 
It also links directly to the SolidAdapter Marketplace entry from ParaglideJS, instead of just the Github Link. 