### PR TITLE
Implement telemetry for `inlang/manage`

### DIFF
--- a/inlang/source-code/manage/package.json
+++ b/inlang/source-code/manage/package.json
@@ -35,6 +35,7 @@
 		"express": "^4.18.2",
 		"lit": "2.8.0",
 		"postcss": "^8.4.31",
+		"posthog-js": "^1.53.2",
 		"tsx": "^4.6.2",
 		"vite-plugin-node-polyfills": "0.16.0",
 		"zod": "^3.22.4"

--- a/inlang/source-code/manage/package.json
+++ b/inlang/source-code/manage/package.json
@@ -35,7 +35,7 @@
 		"express": "^4.18.2",
 		"lit": "2.8.0",
 		"postcss": "^8.4.31",
-		"posthog-js": "^1.53.2",
+		"posthog-js": "^1.91.1",
 		"tsx": "^4.6.2",
 		"vite-plugin-node-polyfills": "0.16.0",
 		"zod": "^3.22.4"

--- a/inlang/source-code/manage/src/components/InlangManage.ts
+++ b/inlang/source-code/manage/src/components/InlangManage.ts
@@ -12,7 +12,7 @@ import { browserAuth, getUser } from "@lix-js/client/src/browser-auth.ts"
 import { tryCatch } from "@inlang/result"
 import { registry } from "@inlang/marketplace-registry"
 import type { MarketplaceManifest } from "../../../versioned-interfaces/marketplace-manifest/dist/interface.js"
-import posthog from "posthog-js"
+import { posthog } from "posthog-js"
 
 type ManifestWithVersion = MarketplaceManifest & { version: string }
 
@@ -127,7 +127,7 @@ export class InlangManage extends TwLitElement {
 			!window.location.host.includes("127.0.0.1") &&
 			!window.location.host.includes("localhost")
 		) {
-			posthog.init(publicEnv.PUBLIC_POSTHOG_TOKEN, { api_host: "https://manage.inlang.com" })
+			posthog.init(publicEnv.PUBLIC_POSTHOG_TOKEN!, { api_host: "https://manage.inlang.com" })
 		}
 
 		if (window.location.search !== "" && window.location.pathname !== "") {
@@ -564,6 +564,17 @@ export class InlangManage extends TwLitElement {
 																			></doc-icon>
 																		</a>
 																		<a
+																			@click=${() => {
+																				posthog.capture("Uninstall module", {
+																					$set: {
+																						name:
+																							typeof this.user === "object"
+																								? this.user.username
+																								: undefined,
+																					},
+																					$set_once: { initial_url: "https://manage.inlang.com" },
+																				})
+																			}}
 																			href=${`/uninstall?repo=${this.url.repo}&project=${this.url.project}&module=${module.id}`}
 																			class="text-red-500 text-sm font-medium transition-colors hover:text-red-400"
 																		>
@@ -638,7 +649,7 @@ export class InlangManage extends TwLitElement {
 																		</a>
 																		<a
 																			@click=${() => {
-																				posthog.capture("event_name", {
+																				posthog.capture("Uninstall module", {
 																					$set: {
 																						name:
 																							typeof this.user === "object"

--- a/inlang/source-code/manage/src/components/InlangManage.ts
+++ b/inlang/source-code/manage/src/components/InlangManage.ts
@@ -123,11 +123,7 @@ export class InlangManage extends TwLitElement {
 		super.connectedCallback()
 
 		/* Initialize Telemetry via Posthog */
-		if (
-			!window.location.host.includes("127.0.0.1") &&
-			!window.location.host.includes("localhost") &&
-			publicEnv.PUBLIC_POSTHOG_TOKEN
-		) {
+		if (publicEnv.PUBLIC_POSTHOG_TOKEN) {
 			posthog.init(publicEnv.PUBLIC_POSTHOG_TOKEN ?? "placeholder", {
 				api_host: "https://eu.posthog.com",
 			})

--- a/inlang/source-code/manage/src/components/InlangManage.ts
+++ b/inlang/source-code/manage/src/components/InlangManage.ts
@@ -122,12 +122,17 @@ export class InlangManage extends TwLitElement {
 	override async connectedCallback() {
 		super.connectedCallback()
 
-		/* Implement Telemetry */
+		/* Initialize Telemetry via Posthog */
 		if (
 			!window.location.host.includes("127.0.0.1") &&
-			!window.location.host.includes("localhost")
+			!window.location.host.includes("localhost") &&
+			publicEnv.PUBLIC_POSTHOG_TOKEN
 		) {
-			posthog.init(publicEnv.PUBLIC_POSTHOG_TOKEN!, { api_host: "https://manage.inlang.com" })
+			posthog.init(publicEnv.PUBLIC_POSTHOG_TOKEN ?? "placeholder", {
+				api_host: "https://eu.posthog.com",
+			})
+		} else if (publicEnv.PUBLIC_POSTHOG_TOKEN === undefined) {
+			return console.warn("Posthog token is not set. Telemetry will not be initialized.")
 		}
 
 		if (window.location.search !== "" && window.location.pathname !== "") {

--- a/inlang/source-code/manage/src/components/InlangManage.ts
+++ b/inlang/source-code/manage/src/components/InlangManage.ts
@@ -12,6 +12,7 @@ import { browserAuth, getUser } from "@lix-js/client/src/browser-auth.ts"
 import { tryCatch } from "@inlang/result"
 import { registry } from "@inlang/marketplace-registry"
 import type { MarketplaceManifest } from "../../../versioned-interfaces/marketplace-manifest/dist/interface.js"
+import posthog from "posthog-js"
 
 type ManifestWithVersion = MarketplaceManifest & { version: string }
 
@@ -120,6 +121,15 @@ export class InlangManage extends TwLitElement {
 
 	override async connectedCallback() {
 		super.connectedCallback()
+
+		/* Implement Telemetry */
+		if (
+			!window.location.host.includes("127.0.0.1") &&
+			!window.location.host.includes("localhost")
+		) {
+			posthog.init(publicEnv.PUBLIC_POSTHOG_TOKEN, { api_host: "https://manage.inlang.com" })
+		}
+
 		if (window.location.search !== "" && window.location.pathname !== "") {
 			const url = {
 				path: window.location.pathname.replace("/", ""),
@@ -627,6 +637,17 @@ export class InlangManage extends TwLitElement {
 																			></doc-icon>
 																		</a>
 																		<a
+																			@click=${() => {
+																				posthog.capture("event_name", {
+																					$set: {
+																						name:
+																							typeof this.user === "object"
+																								? this.user.username
+																								: undefined,
+																					},
+																					$set_once: { initial_url: "https://manage.inlang.com" },
+																				})
+																			}}
 																			href=${`/uninstall?repo=${this.url.repo}&project=${this.url.project}&module=${module.id}`}
 																			class="text-red-500 text-sm font-medium transition-colors hover:text-red-400"
 																		>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,7 +705,7 @@ importers:
         specifier: ^8.4.31
         version: 8.4.31
       posthog-js:
-        specifier: ^1.53.2
+        specifier: ^1.91.1
         version: 1.91.1
       tsx:
         specifier: ^4.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,6 +704,9 @@ importers:
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
+      posthog-js:
+        specifier: ^1.53.2
+        version: 1.91.1
       tsx:
         specifier: ^4.6.2
         version: 4.6.2
@@ -7334,6 +7337,7 @@ packages:
 
   /@tootallnate/quickjs-emscripten@0.23.0:
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+    requiresBuild: true
 
   /@ts-morph/bootstrap@0.20.0:
     resolution: {integrity: sha512-F7MfQ5Gt1dCVaGU+AbEzoLbG2sIXHVXPTRO5wzBfBw1loeSLJ0dWI0Ns97NTX2w7RTKHDRP2VrTvMjaQZsLA1g==}
@@ -9001,6 +9005,7 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
+    requiresBuild: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -9206,6 +9211,7 @@ packages:
   /ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       tslib: 2.6.2
 
@@ -9402,6 +9408,7 @@ packages:
   /basic-ftp@5.0.3:
     resolution: {integrity: sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==}
     engines: {node: '>=10.0.0'}
+    requiresBuild: true
 
   /bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
@@ -10495,6 +10502,7 @@ packages:
   /data-uri-to-buffer@6.0.1:
     resolution: {integrity: sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==}
     engines: {node: '>= 14'}
+    requiresBuild: true
 
   /data-urls@4.0.0:
     resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
@@ -10771,6 +10779,7 @@ packages:
   /degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+    requiresBuild: true
     dependencies:
       ast-types: 0.13.4
       escodegen: 2.1.0
@@ -11400,6 +11409,7 @@ packages:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
+    requiresBuild: true
     dependencies:
       esprima: 4.0.1
       estraverse: 5.3.0
@@ -12734,6 +12744,7 @@ packages:
   /get-uri@6.0.2:
     resolution: {integrity: sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==}
     engines: {node: '>= 14'}
+    requiresBuild: true
     dependencies:
       basic-ftp: 5.0.3
       data-uri-to-buffer: 6.0.1
@@ -13596,9 +13607,11 @@ packages:
 
   /ip@1.1.8:
     resolution: {integrity: sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==}
+    requiresBuild: true
 
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
+    requiresBuild: true
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -14658,10 +14671,12 @@ packages:
 
   /loglevel-plugin-prefix@0.8.4:
     resolution: {integrity: sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==}
+    requiresBuild: true
 
   /loglevel@1.8.1:
     resolution: {integrity: sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==}
     engines: {node: '>= 0.6.0'}
+    requiresBuild: true
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -15633,6 +15648,7 @@ packages:
   /netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+    requiresBuild: true
 
   /next@13.5.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==}
@@ -16305,6 +16321,7 @@ packages:
   /pac-resolver@7.0.0:
     resolution: {integrity: sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==}
     engines: {node: '>= 14'}
+    requiresBuild: true
     dependencies:
       degenerator: 5.0.1
       ip: 1.1.8
@@ -18104,6 +18121,7 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    requiresBuild: true
 
   /smartwrap@2.0.2:
     resolution: {integrity: sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==}
@@ -18135,6 +18153,7 @@ packages:
   /socks@2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
+    requiresBuild: true
     dependencies:
       ip: 2.0.0
       smart-buffer: 4.2.0
@@ -18905,6 +18924,7 @@ packages:
 
   /tar-stream@3.1.6:
     resolution: {integrity: sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==}
+    requiresBuild: true
     dependencies:
       b4a: 1.6.4
       fast-fifo: 1.3.2


### PR DESCRIPTION
This PR adds telemetry to the inlang/manage website, specifically for tracking the behavior of how many people uninstall a certain module.