### PR TITLE
Add development option to install commands

### DIFF
--- a/inlang/source-code/cli/README.md
+++ b/inlang/source-code/cli/README.md
@@ -48,13 +48,13 @@ The CLI allows you to validate your inlang project. This is useful if you want t
 You can install the @inlang/cli with this command:
 
 ```sh
-npm install @inlang/cli
+npm install -D @inlang/cli
 ```
 
 or
 
 ```sh
-yarn add @inlang/cli
+yarn add --dev @inlang/cli
 ```
 
 best


### PR DESCRIPTION
The guide said to install @inlang/cli as a regular dependency. This commit adds the development option to the npm and yarn install commands so that the package can be installed as a devDependency.