### PR TITLE
Fix error in language switcher example

### DIFF
--- a/inlang/guides/build-a-global-svelte-app/build-a-global-svelte-app.md
+++ b/inlang/guides/build-a-global-svelte-app/build-a-global-svelte-app.md
@@ -280,7 +280,7 @@ export function route(path: string, lang: AvailableLanguageTag) {
 function withoutLanguageTag(path: string) {
 	const [_, maybeLang, ...rest] = path.split("/")
 	if (availableLanguageTags.includes(maybeLang as AvailableLanguageTag)) {
-		return rest.join("/")
+		return `/${rest.join('/')}`
 	}
 	return path
 }


### PR DESCRIPTION
The "withoutLanguageTag" function in the language switcher example provided had a mistake in the first return statement. The mistake was a missing '/' at the beginning of the returned string, which caused wrong paths to be returned.