### PR TITLE
Release paraglide Caching

### DIFF
--- a/.changeset/hot-mails-enjoy.md
+++ b/.changeset/hot-mails-enjoy.md
@@ -1,0 +1,8 @@
+---
+"@inlang/paraglide-js-adapter-rollup": patch
+"@inlang/paraglide-js-adapter-unplugin": patch
+"@inlang/paraglide-js-adapter-vite": patch
+"@inlang/paraglide-js-adapter-webpack": patch
+---
+
+fix: check if messages have actually changed before recompiling

--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @inlang/paraglide-js
 
+## 1.0.0-prerelease.20
+
+Paraglide now checks if the messages have actually changed before recompiling. This should improve reliability and performance.
+
 ## 1.0.0-prerelease.19
 
 fix: Fix inlang/internal#195

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.19",
+	"version": "1.0.0-prerelease.20",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Last week I built caching behaviour into paraglide to make sure it only recompiles when messages change. This hasn't been released yet, so this PR will do that.

This may help with #1929, but that might also be and SDK problem. 