### PR TITLE
Fix broken postinstall

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.21",
+	"version": "1.0.0-prerelease.22",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"

--- a/inlang/source-code/valid-js-identifier/package.json
+++ b/inlang/source-code/valid-js-identifier/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inlang/valid-js-identifier",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Validates that a string is a valid JavaScript identifier",
     "type": "module",
     "main": "src/index.js",
@@ -10,9 +10,8 @@
         "access": "public"
     },
     "scripts": {
-        "postinstall": "node ./dts.js",
         "prepublishOnly": "node ./dts.js",
-        "lint": "eslint src",
+        "lint": "node ./dts.js && eslint src",
         "build": "node ./dts.js",
         "test": "vitest run",
         "clean": "rm -rf ./node_modules ./types"


### PR DESCRIPTION
This PR fixes the broken postinstall in `@inlang/valid-js-identifier` & bumps paraglides version so it no longer depends on the broken one